### PR TITLE
Add VRChat Mic Mute Sync

### DIFF
--- a/src/puripuly_heart/config/settings.py
+++ b/src/puripuly_heart/config/settings.py
@@ -153,6 +153,7 @@ class LLMSettings:
 
 @dataclass(slots=True)
 class OSCSettings:
+
     host: str = "127.0.0.1"
     port: int = 9000
     chatbox_address: str = "/chatbox/input"
@@ -161,7 +162,7 @@ class OSCSettings:
     chatbox_max_chars: int = 144
     cooldown_s: float = 1.5
     ttl_s: float = 7.0
-
+    vrc_mic_intercept: bool = True #mic switch开关
     def validate(self) -> None:
         if not self.host:
             raise ValueError("host must be non-empty")
@@ -364,6 +365,7 @@ def to_dict(settings: AppSettings) -> dict[str, Any]:
             "chatbox_max_chars": settings.osc.chatbox_max_chars,
             "cooldown_s": settings.osc.cooldown_s,
             "ttl_s": settings.osc.ttl_s,
+            "vrc_mic_intercept": settings.osc.vrc_mic_intercept,
         },
         "secrets": {
             "backend": settings.secrets.backend.value,
@@ -598,6 +600,7 @@ def from_dict(data: dict[str, Any]) -> AppSettings:
             chatbox_max_chars=int(data.get("osc", {}).get("chatbox_max_chars", 144)),
             cooldown_s=float(data.get("osc", {}).get("cooldown_s", 1.5)),
             ttl_s=float(data.get("osc", {}).get("ttl_s", 7.0)),
+            vrc_mic_intercept=bool(data.get("osc", {}).get("vrc_mic_intercept", True)),
         ),
         secrets=SecretsSettings(
             backend=SecretsBackend(

--- a/src/puripuly_heart/core/orchestrator/hub.py
+++ b/src/puripuly_heart/core/orchestrator/hub.py
@@ -118,7 +118,9 @@ class ClientHub:
     _last_promo_time: float | None = None
     _promo_eligible: bool = False
     _merge_buffer: _MergeBuffer | None = None
-
+    vrc_muted: bool = False  # VRChat mic mute state
+    _active_speech_id: object = None  # To track if user is actively speaking (for mic mute handling)
+    vrc_mic_intercept: bool = True  # Whether to intercept VRChat mic state changes (configurable via OSCSettings)
     async def start(self, *, auto_flush_osc: bool = False) -> None:
         if self._running:
             return
@@ -166,6 +168,8 @@ class ClientHub:
 
         if self.llm is not None:
             await self.llm.close()
+    
+
 
     def mark_promo_eligible(self) -> None:
         """Mark that user clicked STT button. Next STREAMING state will send promo."""
@@ -215,6 +219,24 @@ class ClientHub:
             self._translation_history.pop(0)
 
     async def handle_vad_event(self, event: VadEvent) -> None:
+        # === 闭麦拦截核心逻辑 ===
+        if getattr(self, "vrc_mic_intercept", True):
+            if isinstance(event, SpeechStart):
+                if self.vrc_muted:
+                    return  # 闭麦时，拒绝开始新的识别
+                self._active_speech_id = event.utterance_id
+
+            elif isinstance(event, SpeechChunk):
+                if self.vrc_muted or getattr(self, "_active_speech_id", None) != event.utterance_id:
+                    return  # 闭麦了，或者这段语音压根没开始过，丢弃声音数据
+
+            elif isinstance(event, SpeechEnd):
+                if getattr(self, "_active_speech_id", None) != event.utterance_id:
+                    return  # 如果这段语音一开始就被拦截了，就不要发结束信号给 STT
+                self._active_speech_id = None  # 正常结束，清理状态
+        # ==========================
+
+        # === 以下是原版底层逻辑 (请勿改动缩进) ===
         if isinstance(event, SpeechStart):
             if self.low_latency_mode:
                 self._mark_resume_pending(event)

--- a/src/puripuly_heart/core/orchestrator/hub.py
+++ b/src/puripuly_heart/core/orchestrator/hub.py
@@ -219,7 +219,7 @@ class ClientHub:
             self._translation_history.pop(0)
 
     async def handle_vad_event(self, event: VadEvent) -> None:
-        # === 闭麦拦截核心逻辑 ===
+        # 闭麦拦截
         if getattr(self, "vrc_mic_intercept", True):
             if isinstance(event, SpeechStart):
                 if self.vrc_muted:
@@ -234,9 +234,7 @@ class ClientHub:
                 if getattr(self, "_active_speech_id", None) != event.utterance_id:
                     return  # 如果这段语音一开始就被拦截了，就不要发结束信号给 STT
                 self._active_speech_id = None  # 正常结束，清理状态
-        # ==========================
 
-        # === 以下是原版底层逻辑 (请勿改动缩进) ===
         if isinstance(event, SpeechStart):
             if self.low_latency_mode:
                 self._mark_resume_pending(event)

--- a/src/puripuly_heart/core/osc/receiver.py
+++ b/src/puripuly_heart/core/osc/receiver.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+from pythonosc.dispatcher import Dispatcher
+from pythonosc.osc_server import AsyncIOOSCUDPServer
+
+if TYPE_CHECKING:
+    from puripuly_heart.core.orchestrator.hub import ClientHub
+
+logger = logging.getLogger(__name__)
+
+class VrcOscReceiver:
+    def __init__(self, hub: ClientHub, host: str = "127.0.0.1", port: int = 9001):
+        self.hub = hub
+        self.host = host
+        self.port = port
+        self.transport = None
+        self._mute_task: asyncio.Task | None = None
+        self.mute_delay = 1.2  # 延迟 1.2 秒闭麦，完美包容 PTT 习惯，可自行微调
+
+    def mute_handler(self, address: str, *args) -> None:
+        if not args:
+            return
+        is_muted = bool(args[0])
+
+        # 每次收到 OSC 信号，先取消之前的延时任务（防止快速开关麦导致状态错乱）
+        if self._mute_task and not self._mute_task.done():
+            self._mute_task.cancel()
+
+        loop = asyncio.get_running_loop()
+        self._mute_task = loop.create_task(self._apply_mute_state(is_muted))
+
+    async def _apply_mute_state(self, is_muted: bool) -> None:
+        try:
+            if is_muted:
+                # 核心逻辑：如果是闭麦，等待 1.2 秒，让尾音飞一会儿
+                await asyncio.sleep(self.mute_delay)
+            
+            # 如果是开麦，或者延时结束了，才真正修改 Hub 的状态
+            if self.hub.vrc_muted != is_muted:
+                logger.info(f"[OSC Receiver] VRChat Mic Muted State Applied: {is_muted}")
+                self.hub.vrc_muted = is_muted
+
+        except asyncio.CancelledError:
+            # 如果在等待的 1.2 秒内，用户又按下了开麦键，任务会被取消，什么都不做
+            pass
+
+    async def start(self) -> None:
+        dispatcher = Dispatcher()
+        dispatcher.map("/avatar/parameters/MuteSelf", self.mute_handler)
+
+        loop = asyncio.get_running_loop()
+        server = AsyncIOOSCUDPServer((self.host, self.port), dispatcher, loop)
+        
+        self.transport, protocol = await server.create_serve_endpoint()
+        logger.info(f"[OSC Receiver] Listening on {self.host}:{self.port} for VRChat parameters")
+
+    def stop(self) -> None:
+        if self._mute_task and not self._mute_task.done():
+            self._mute_task.cancel()
+        if self.transport:
+            self.transport.close()
+            logger.info("[OSC Receiver] Stopped listening.")

--- a/src/puripuly_heart/core/osc/receiver.py
+++ b/src/puripuly_heart/core/osc/receiver.py
@@ -19,7 +19,7 @@ class VrcOscReceiver:
         self.port = port
         self.transport = None
         self._mute_task: asyncio.Task | None = None
-        self.mute_delay = 1.2  # 延迟 1.2 秒闭麦，完美包容 PTT 习惯，可自行微调
+        self.mute_delay = 0.4  # 延迟 0.4 秒闭麦，完美包容 PTT 习惯，可自行微调
 
     def mute_handler(self, address: str, *args) -> None:
         if not args:
@@ -36,7 +36,7 @@ class VrcOscReceiver:
     async def _apply_mute_state(self, is_muted: bool) -> None:
         try:
             if is_muted:
-                # 核心逻辑：如果是闭麦，等待 1.2 秒，让尾音飞一会儿
+                # 核心逻辑：如果是闭麦，等待 0.4 秒，让尾音飞一会儿
                 await asyncio.sleep(self.mute_delay)
             
             # 如果是开麦，或者延时结束了，才真正修改 Hub 的状态
@@ -45,7 +45,7 @@ class VrcOscReceiver:
                 self.hub.vrc_muted = is_muted
 
         except asyncio.CancelledError:
-            # 如果在等待的 1.2 秒内，用户又按下了开麦键，任务会被取消，什么都不做
+            # 如果在等待的 0.4 秒内，用户又按下了开麦键，任务会被取消，什么都不做
             pass
 
     async def start(self) -> None:

--- a/src/puripuly_heart/data/i18n/en.json
+++ b/src/puripuly_heart/data/i18n/en.json
@@ -138,6 +138,7 @@
   "toggle.on.description": "Starts translating while you speak",
   "toggle.off": "Stable",
   "toggle.off.description": "Translates after you finish speaking. Saves costs",
+  "settings.vrc_mic_intercept": "VRChat Mic Sync",
   "settings.vrc_mic.on": "On",
   "settings.vrc_mic.off": "Off"
 }

--- a/src/puripuly_heart/data/i18n/en.json
+++ b/src/puripuly_heart/data/i18n/en.json
@@ -137,5 +137,7 @@
   "toggle.on": "Fast Response",
   "toggle.on.description": "Starts translating while you speak",
   "toggle.off": "Stable",
-  "toggle.off.description": "Translates after you finish speaking. Saves costs"
+  "toggle.off.description": "Translates after you finish speaking. Saves costs",
+  "settings.vrc_mic.on": "On",
+  "settings.vrc_mic.off": "Off"
 }

--- a/src/puripuly_heart/data/i18n/ko.json
+++ b/src/puripuly_heart/data/i18n/ko.json
@@ -137,5 +137,7 @@
   "toggle.on": "빠른 응답",
   "toggle.on.description": "말하는 동안 바로 번역을 시작해요",
   "toggle.off": "안정",
-  "toggle.off.description": "말이 끝난 뒤 번역해요. 비용을 아낄 수 있어요"
+  "toggle.off.description": "말이 끝난 뒤 번역해요. 비용을 아낄 수 있어요",
+  "settings.vrc_mic.on": "켜짐",
+  "settings.vrc_mic.off": "꺼짐"
 }

--- a/src/puripuly_heart/data/i18n/ko.json
+++ b/src/puripuly_heart/data/i18n/ko.json
@@ -138,6 +138,7 @@
   "toggle.on.description": "말하는 동안 바로 번역을 시작해요",
   "toggle.off": "안정",
   "toggle.off.description": "말이 끝난 뒤 번역해요. 비용을 아낄 수 있어요",
+  "settings.vrc_mic_intercept": "VRChat 마이크 동기화",
   "settings.vrc_mic.on": "켜짐",
   "settings.vrc_mic.off": "꺼짐"
 }

--- a/src/puripuly_heart/data/i18n/zh-CN.json
+++ b/src/puripuly_heart/data/i18n/zh-CN.json
@@ -137,5 +137,7 @@
     "toggle.on": "快速响应",
     "toggle.on.description": "说话时立即开始翻译",
     "toggle.off": "稳定",
-    "toggle.off.description": "说完后再翻译，节省费用"
+    "toggle.off.description": "说完后再翻译，节省费用",
+    "settings.vrc_mic.on": "开启",
+    "settings.vrc_mic.off": "关闭"
 }

--- a/src/puripuly_heart/data/i18n/zh-CN.json
+++ b/src/puripuly_heart/data/i18n/zh-CN.json
@@ -138,6 +138,7 @@
     "toggle.on.description": "说话时立即开始翻译",
     "toggle.off": "稳定",
     "toggle.off.description": "说完后再翻译，节省费用",
+    "settings.vrc_mic_intercept": "VRChat 闭麦同步",
     "settings.vrc_mic.on": "开启",
     "settings.vrc_mic.off": "关闭"
 }

--- a/src/puripuly_heart/ui/controller.py
+++ b/src/puripuly_heart/ui/controller.py
@@ -61,7 +61,7 @@ class GuiController:
     sender: VrchatOscUdpSender | None = None
     osc: SmartOscQueue | None = None
     hub: ClientHub | None = None
-
+    receiver: VrcOscReceiver | None = None
     _bridge_task: asyncio.Task[None] | None = None
     _mic_task: asyncio.Task[None] | None = None
     _audio_source: SoundDeviceAudioSource | None = None
@@ -144,6 +144,10 @@ class GuiController:
 
     async def stop(self) -> None:
         await self.set_stt_enabled(False)
+        #CUT OFF
+        if getattr(self, "receiver", None) is not None:
+            self.receiver.stop()
+            self.receiver = None
 
         if self._bridge_task:
             self._bridge_task.cancel()
@@ -504,6 +508,9 @@ class GuiController:
         self.sender = sender
         self.osc = osc
         self.hub = hub
+
+        self.receiver = VrcOscReceiver(hub=self.hub, host="127.0.0.1", port=9001)
+        await self.receiver.start()
 
     async def _start_mic_loop(self) -> None:
         if self._mic_task is not None:

--- a/src/puripuly_heart/ui/controller.py
+++ b/src/puripuly_heart/ui/controller.py
@@ -21,6 +21,7 @@ from puripuly_heart.config.settings import (
     load_settings,
     save_settings,
 )
+from puripuly_heart.core.osc.receiver import VrcOscReceiver
 from puripuly_heart.core.audio.source import (
     SoundDeviceAudioSource,
     resolve_sounddevice_input_device,

--- a/src/puripuly_heart/ui/controller.py
+++ b/src/puripuly_heart/ui/controller.py
@@ -62,6 +62,7 @@ class GuiController:
     osc: SmartOscQueue | None = None
     hub: ClientHub | None = None
     receiver: VrcOscReceiver | None = None
+
     _bridge_task: asyncio.Task[None] | None = None
     _mic_task: asyncio.Task[None] | None = None
     _audio_source: SoundDeviceAudioSource | None = None
@@ -144,7 +145,7 @@ class GuiController:
 
     async def stop(self) -> None:
         await self.set_stt_enabled(False)
-        #CUT OFF
+        #cut off
         if getattr(self, "receiver", None) is not None:
             self.receiver.stop()
             self.receiver = None
@@ -311,6 +312,8 @@ class GuiController:
                 if settings.stt.low_latency_mode
                 else 1.1
             )
+            self.hub.vrc_mic_intercept = settings.osc.vrc_mic_intercept
+            logger.info(f"[Settings] VRC mic intercept: {settings.osc.vrc_mic_intercept}")
 
         # Restart STT only when runtime STT-relevant settings changed.
         current_signature = self._build_stt_runtime_signature(settings)
@@ -503,12 +506,13 @@ class GuiController:
                 if self.settings.stt.low_latency_mode
                 else 1.1
             ),
+            vrc_mic_intercept=self.settings.osc.vrc_mic_intercept,
         )
 
         self.sender = sender
         self.osc = osc
         self.hub = hub
-
+        # --- 新增：给接收器插电并启动！ ---
         self.receiver = VrcOscReceiver(hub=self.hub, host="127.0.0.1", port=9001)
         await self.receiver.start()
 

--- a/src/puripuly_heart/ui/views/settings.py
+++ b/src/puripuly_heart/ui/views/settings.py
@@ -420,7 +420,7 @@ class SettingsView(ft.Column):
             self._on_vrc_mic_click,
         )
         self._vrc_mic_title = ft.Text(
-            t("settings.vrc_mic_intercept"),  # <--- 去掉了的中文
+            t("settings.vrc_mic_intercept"), #new name
             size=24,
             weight=ft.FontWeight.BOLD,
             color=COLOR_NEUTRAL,

--- a/src/puripuly_heart/ui/views/settings.py
+++ b/src/puripuly_heart/ui/views/settings.py
@@ -923,6 +923,7 @@ class SettingsView(ft.Column):
         if not self._settings:
             return
         new_value = value == "on"
+        logger.info(f"[Settings] VRC mic intercept toggled: {new_value}")
         self._settings.osc.vrc_mic_intercept = new_value
 
         self._vrc_mic_text.content.value = t("settings.vrc_mic.on" if new_value else "settings.vrc_mic.off")
@@ -1033,8 +1034,9 @@ class SettingsView(ft.Column):
             self._low_latency_text.content.value = t(
                 "toggle.on" if self._settings.stt.low_latency_mode else "toggle.off"
             )
-            
-            "settings.vrc_mic.on" if self._settings.osc.vrc_mic_intercept else "settings.vrc_mic.off"
+            self._vrc_mic_text.content.value = t(
+                "settings.vrc_mic.on" if self._settings.osc.vrc_mic_intercept else "settings.vrc_mic.off"
+            )
 
         # Qwen Region label
         if self._settings:

--- a/src/puripuly_heart/ui/views/settings.py
+++ b/src/puripuly_heart/ui/views/settings.py
@@ -901,7 +901,10 @@ class SettingsView(ft.Column):
         self._emit_settings_changed()
 
     def _on_vrc_mic_click(self, e) -> None:
-        """打开 VRC 闭麦同步选项框"""
+        """打开 VRC 闭麦同步选项框
+        
+        Open VRC mic intercept selection modal.
+        """
         if not self.page:
             return
         options = [
@@ -919,7 +922,10 @@ class SettingsView(ft.Column):
         modal.open(current)
 
     def _on_vrc_mic_selected(self, value: str) -> None:
-        """处理选项卡的选择结果"""
+        """处理选项卡的选择结果
+        
+        Handle VRC mic intercept selection result.
+        """
         if not self._settings:
             return
         new_value = value == "on"

--- a/src/puripuly_heart/ui/views/settings.py
+++ b/src/puripuly_heart/ui/views/settings.py
@@ -414,8 +414,25 @@ class SettingsView(ft.Column):
             ),
         )
         row5 = persona_card
-
-        self.controls = [row1, row2, row3, row4, row5]
+        # === Row 6: VRChat 同步开关 (1x1) ===
+        self._vrc_mic_text = self._build_clickable_text(
+            t("settings.vrc_mic.on"),
+            self._on_vrc_mic_click,
+        )
+        self._vrc_mic_title = ft.Text(
+            t("settings.vrc_mic_intercept"),  # <--- 去掉了的中文
+            size=24,
+            weight=ft.FontWeight.BOLD,
+            color=COLOR_NEUTRAL,
+        )
+        vrc_mic_card = self._wrap_card(
+            ft.Column([self._vrc_mic_title, self._vrc_mic_text], spacing=0, expand=True)
+        )
+        row6 = ft.Container(
+            content=ft.Row([vrc_mic_card, ft.Container(expand=True)], spacing=16, expand=True),
+            height=280,
+        )
+        self.controls = [row1, row2, row3, row4, row5, row6]
 
     def _populate_host_apis(self) -> None:
         """Legacy hook for tests; host APIs are handled by AudioSettings."""
@@ -481,6 +498,10 @@ class SettingsView(ft.Column):
         self._vad_slider.label = f"{settings.stt.vad_speech_threshold:.2f}"
         self._low_latency_text.content.value = t(
             "toggle.on" if settings.stt.low_latency_mode else "toggle.off"
+        )
+        # --- 新增：读取 VRChat 同步开关状态 ---
+        self._vrc_mic_text.content.value = t(
+            "settings.vrc_mic.on" if settings.osc.vrc_mic_intercept else "settings.vrc_mic.off"
         )
 
         # Prompt
@@ -879,6 +900,36 @@ class SettingsView(ft.Column):
         self._settings.stt.vad_speech_threshold = new_vad
         self._emit_settings_changed()
 
+    def _on_vrc_mic_click(self, e) -> None:
+        """打开 VRC 闭麦同步选项框"""
+        if not self.page:
+            return
+        options = [
+            OptionItem(value="on", label=t("settings.vrc_mic.on")),   # 
+            OptionItem(value="off", label=t("settings.vrc_mic.off")), # new name
+        ]
+        current = "on" if self._settings.osc.vrc_mic_intercept else "off"
+        modal = SettingsModal(
+            self.page,
+            t("settings.vrc_mic_intercept"),  
+            options,
+            self._on_vrc_mic_selected,
+            show_description=False,
+        )
+        modal.open(current)
+
+    def _on_vrc_mic_selected(self, value: str) -> None:
+        """处理选项卡的选择结果"""
+        if not self._settings:
+            return
+        new_value = value == "on"
+        self._settings.osc.vrc_mic_intercept = new_value
+
+        self._vrc_mic_text.content.value = t("settings.vrc_mic.on" if new_value else "settings.vrc_mic.off")
+        if self.page:
+            self._vrc_mic_text.update()
+        self._emit_settings_changed()
+
     def _on_low_latency_click(self, e) -> None:
         """Open low latency mode selection modal."""
         if not self.page:
@@ -958,7 +1009,10 @@ class SettingsView(ft.Column):
         self._vad_title.value = t("settings.vad_sensitivity")
         self._low_latency_title.value = t("settings.low_latency_mode")
         self._persona_title.value = t("settings.section.persona")
+        self._vrc_mic_title.value = t("settings.vrc_mic_intercept")
         self._reset_prompt_btn.text = t("settings.reset_prompt")
+        
+        self._vrc_mic_title.value = t("settings.vrc_mic_intercept")
 
         # Update dynamic buttons by replacing the entire style object
         ui_font = font_for_language(get_locale())
@@ -979,6 +1033,8 @@ class SettingsView(ft.Column):
             self._low_latency_text.content.value = t(
                 "toggle.on" if self._settings.stt.low_latency_mode else "toggle.off"
             )
+            
+            "settings.vrc_mic.on" if self._settings.osc.vrc_mic_intercept else "settings.vrc_mic.off"
 
         # Qwen Region label
         if self._settings:


### PR DESCRIPTION
1. **Settings Toggle**: Added a UI switch in the Settings page (`Settings -> VRChat Mic Sync`) with i18n support.
2. **Cost Saving**: When muted in VRChat, the audio stream will be intercepted at the `hub.py` level, preventing it from being sent to the STT provider.
3. **PTT Friendly (Anti-Truncation)**: Added a 1.2s delay in `receiver.py` when muting. This ensures the trailing audio and the `SpeechEnd` event are perfectly captured when a user releases their Push-To-Talk button quickly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * VRChat 마이크 동기화 기능 추가: VRChat의 마이크 뮤트 상태를 애플리케이션과 자동으로 동기화
  * 설정에서 VRChat 마이크 동기화 활성화/비활성화 토글 제공
  * 음성 감지 이벤트 필터링으로 마이크 뮤트 상태 반영
  * 다국어 지원 (영어, 한국어, 중국어 간체)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->