### PR TITLE
fix(overlay): re-assert topmost z-order after locking

### DIFF
--- a/src/puripuly_heart/ui/desktop_overlay.py
+++ b/src/puripuly_heart/ui/desktop_overlay.py
@@ -55,6 +55,11 @@ from puripuly_heart.core.overlay.protocol import (
     OverlayPresentationBlock,
     OverlayPresentationSnapshot,
 )
+from puripuly_heart.ui.desktop_window_zorder import (
+    NoopWindowZOrderPort,
+    WindowZOrderPort,
+    create_window_z_order_port,
+)
 from puripuly_heart.ui.fonts import assets_dir
 from puripuly_heart.ui.i18n import t_for_locale
 
@@ -2220,12 +2225,18 @@ class StdoutLifecycleSink:
 type FletAppRunner = Callable[[Callable[[Any], object]], Awaitable[None]]
 type OverlayEventSink = Callable[[dict[str, object]], Awaitable[None]]
 type PreviewAppRunner = Callable[[Callable[[Any], object]], object]
+type FletProcessInfoProvider = Callable[[], tuple[int, str | None] | None]
+type ScheduledCallbackTask = asyncio.Future[Any] | ConcurrentFuture[Any]
 
 
-async def _default_flet_app_runner(target: Callable[[Any], object]) -> None:
+async def _default_flet_app_runner(
+    target: Callable[[Any], object],
+    *,
+    on_process_started: Callable[[int, str | None], None] | None = None,
+) -> None:
     import flet as ft
 
-    with _patch_flet_view_hidden_launcher():
+    with _patch_flet_view_hidden_launcher(on_process_started=on_process_started):
         await ft.app_async(
             target=target,
             view=ft.AppView.FLET_APP_HIDDEN,
@@ -2234,11 +2245,28 @@ async def _default_flet_app_runner(target: Callable[[Any], object]) -> None:
 
 
 @contextlib.contextmanager
-def _patch_flet_view_hidden_launcher():
+def _patch_flet_view_hidden_launcher(
+    *,
+    on_process_started: Callable[[int, str | None], None] | None = None,
+):
     import flet_desktop
 
+    async def launch(
+        page_url: str,
+        assets_dir: str | None,
+        hidden: bool,
+    ) -> tuple[asyncio.subprocess.Process, str | None]:
+        process, pid_file = await _open_flet_view_hidden_without_startup_flash(
+            page_url,
+            assets_dir,
+            hidden,
+        )
+        if on_process_started is not None and process.pid is not None:
+            on_process_started(int(process.pid), pid_file)
+        return process, pid_file
+
     original = flet_desktop.open_flet_view_async
-    flet_desktop.open_flet_view_async = _open_flet_view_hidden_without_startup_flash
+    flet_desktop.open_flet_view_async = launch
     try:
         yield
     finally:
@@ -2298,8 +2326,39 @@ class FletDesktopRendererWindow:
         bounds_debounce_s: float = 0.15,
         startup_timeout_s: float = 5.0,
         preview_catalog: DesktopOverlayPreviewCatalog | None = None,
+        window_z_order_port: WindowZOrderPort | None = None,
+        window_process_info_provider: FletProcessInfoProvider | None = None,
     ) -> None:
-        self._app_runner = app_runner or _default_flet_app_runner
+        if (
+            app_runner is not None
+            and window_z_order_port is not None
+            and window_process_info_provider is None
+        ):
+            raise ValueError(
+                "window_process_info_provider is required with a custom app_runner "
+                "and window_z_order_port"
+            )
+        if window_z_order_port is not None:
+            self._window_z_order_port = window_z_order_port
+        elif app_runner is None and preview_catalog is None:
+            self._window_z_order_port = create_window_z_order_port()
+        else:
+            self._window_z_order_port = NoopWindowZOrderPort()
+        self._window_z_order_required = window_z_order_port is not None or (
+            app_runner is None and preview_catalog is None and os.name == "nt"
+        )
+        if app_runner is None:
+
+            async def run_default_app(target: Callable[[Any], object]) -> None:
+                await _default_flet_app_runner(
+                    target,
+                    on_process_started=self._record_flet_process,
+                )
+
+            self._app_runner = run_default_app
+        else:
+            self._app_runner = app_runner
+        self._window_process_info_provider = window_process_info_provider
         self._event_sink = event_sink
         self._locale = locale
         self._logging_mode = normalize_overlay_logging_mode(logging_mode)
@@ -2321,8 +2380,13 @@ class FletDesktopRendererWindow:
         self._closed = asyncio.Event()
         self._app_task: asyncio.Task[None] | None = None
         self._page_start_error: BaseException | None = None
+        self._flet_process_pid: int | None = None
+        self._flet_pid_file: str | None = None
+        self._interaction_mode_lock = asyncio.Lock()
+        self._interaction_generation = 0
+        self._window_z_order_task: ScheduledCallbackTask | None = None
         self._bounds_sample_task: asyncio.Task[None] | None = None
-        self._scheduled_callback_tasks: set[asyncio.Future[Any] | ConcurrentFuture[Any]] = set()
+        self._scheduled_callback_tasks: set[ScheduledCallbackTask] = set()
         self._programmatic_bounds_echo_suppression: _ProgrammaticBoundsEchoSuppression | None = None
         self._last_reported_bounds: tuple[float, float, float, float] | None = None
         self._caption_card_width_floor_by_block: dict[tuple[str, str, int], float] = {}
@@ -2424,6 +2488,9 @@ class FletDesktopRendererWindow:
 
     async def close(self) -> None:
         self._closed.set()
+        async with self._interaction_mode_lock:
+            self._interaction_generation += 1
+            await self._cancel_window_z_order_task()
         page = self._page
         if page is not None:
             page.window.on_event = None
@@ -2459,6 +2526,7 @@ class FletDesktopRendererWindow:
                 raise
             except Exception:
                 pass
+        self._window_z_order_port.close()
 
     async def dispatch_snapshot(self, snapshot: OverlayPresentationSnapshot) -> None:
         if snapshot.revision <= self._last_snapshot_revision:
@@ -2574,8 +2642,20 @@ class FletDesktopRendererWindow:
         logger.warning("[DesktopOverlay] Ignoring unsupported desktop runtime control: %r", command)
 
     def _handle_page(self, page: Any) -> None:
+        if self._closed.is_set():
+            window = page.window
+            try:
+                window.close()
+            except Exception:
+                destroy = getattr(window, "destroy", None)
+                if callable(destroy):
+                    with contextlib.suppress(Exception):
+                        destroy()
+            self._page_ready.set()
+            return
         self._page = page
         try:
+            self._bind_window_z_order_process()
             self._configure_base_window(page)
             self._render_page()
             self._page_ready.set()
@@ -2583,6 +2663,32 @@ class FletDesktopRendererWindow:
             self._page_start_error = exc
             self._page_ready.set()
             raise
+
+    def _record_flet_process(self, pid: int, pid_file: str | None) -> None:
+        if self._closed.is_set():
+            return
+        self._flet_process_pid = int(pid) if int(pid) > 0 else None
+        self._flet_pid_file = pid_file
+
+    def _bind_window_z_order_process(self) -> None:
+        provider = self._window_process_info_provider
+        if provider is not None:
+            process_info = provider()
+            if process_info is not None:
+                self._record_flet_process(*process_info)
+        pid = self._flet_process_pid
+        source = "launcher"
+        pid_file = self._flet_pid_file
+        if pid_file:
+            with contextlib.suppress(Exception):
+                recorded_pid = int(Path(pid_file).read_text(encoding="utf-8").strip())
+                if recorded_pid > 0:
+                    pid = recorded_pid
+                    source = "pid_file"
+        if pid is None:
+            return
+        self._window_z_order_port.bind_process(pid)
+        self._emit_detailed_log(f"window_process_bound source={source} pid={pid}")
 
     def _configure_base_window(self, page: Any) -> None:
         import flet as ft
@@ -2735,10 +2841,6 @@ class FletDesktopRendererWindow:
         locked = self._interaction_mode == _DESKTOP_INTERACTION_MODE_PASS_THROUGH
         window = page.window
         window.ignore_mouse_events = locked
-        # Re-assert topmost after locking to prevent fullscreen windowed games
-        # (e.g. VRChat) from stealing z-order. See: #12
-        if locked:
-            window.always_on_top = True
 
     def _reveal_window_if_supported(self) -> None:
         page = self._page
@@ -3158,17 +3260,89 @@ class FletDesktopRendererWindow:
         await self._set_interaction_mode(_DESKTOP_INTERACTION_MODE_EDIT, emit_event=True)
 
     async def _set_interaction_mode(self, mode: str, *, emit_event: bool) -> None:
-        if mode not in _DESKTOP_INTERACTION_MODES:
+        async with self._interaction_mode_lock:
+            if self._closed.is_set():
+                return
+            if mode not in _DESKTOP_INTERACTION_MODES:
+                return
+            if mode == self._interaction_mode:
+                return
+            previous_mode = self._interaction_mode
+            self._interaction_mode = mode
+            self._interaction_generation += 1
+            generation = self._interaction_generation
+            await self._cancel_window_z_order_task()
+            if self._closed.is_set():
+                return
+            self._emit_detailed_log(f"interaction_mode {previous_mode}->{mode}")
+            self._apply_interaction_window_chrome()
+            self._render_page()
+            if mode == _DESKTOP_INTERACTION_MODE_PASS_THROUGH:
+
+                async def reassert_window_z_order() -> None:
+                    await self._reassert_window_z_order(generation)
+
+                task = self._run_page_task(reassert_window_z_order)
+                self._window_z_order_task = task
+                if task is not None:
+                    task.add_done_callback(self._clear_window_z_order_task)
+            if emit_event:
+                await self._emit_overlay_event({"event": "interaction_mode_changed", "mode": mode})
+
+    async def _reassert_window_z_order(self, generation: int) -> None:
+        try:
+            result = await self._window_z_order_port.reassert_topmost_after_click_through()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            if not self._window_z_order_result_is_current(generation):
+                return
+            self._emit_detailed_log(
+                f"topmost_reassert reason=port_error exception_type={type(exc).__name__}"
+            )
+            if self._window_z_order_required:
+                logger.warning(
+                    "[DesktopOverlay] Topmost z-order re-assertion failed: "
+                    "reason=port_error exception_type=%s",
+                    type(exc).__name__,
+                )
+        else:
+            if not self._window_z_order_result_is_current(generation):
+                return
+            self._emit_detailed_log(
+                "topmost_reassert "
+                f"reason={result.reason} applied={result.applied} "
+                f"click_through_confirmed={result.click_through_confirmed} "
+                f"topmost_style_present={result.topmost_style_present} "
+                f"win32_error={result.win32_error}"
+            )
+            if self._window_z_order_required and not result.applied:
+                logger.warning(
+                    "[DesktopOverlay] Topmost z-order re-assertion failed: "
+                    "reason=%s win32_error=%s",
+                    result.reason,
+                    result.win32_error,
+                )
+
+    def _window_z_order_result_is_current(self, generation: int) -> bool:
+        return (
+            not self._closed.is_set()
+            and self._interaction_mode == _DESKTOP_INTERACTION_MODE_PASS_THROUGH
+            and self._interaction_generation == generation
+        )
+
+    def _clear_window_z_order_task(self, task: object) -> None:
+        if self._window_z_order_task is task:
+            self._window_z_order_task = None
+
+    async def _cancel_window_z_order_task(self) -> None:
+        task = self._window_z_order_task
+        self._window_z_order_task = None
+        if task is None or task.done():
             return
-        if mode == self._interaction_mode:
-            return
-        previous_mode = self._interaction_mode
-        self._interaction_mode = mode
-        self._emit_detailed_log(f"interaction_mode {previous_mode}->{mode}")
-        self._apply_interaction_window_chrome()
-        self._render_page()
-        if emit_event:
-            await self._emit_overlay_event({"event": "interaction_mode_changed", "mode": mode})
+        task.cancel()
+        awaitable = task if isinstance(task, asyncio.Future) else asyncio.wrap_future(task)
+        await asyncio.gather(awaitable, return_exceptions=True)
 
     def _apply_window_bounds(self, bounds: dict[str, int | float]) -> None:
         page = self._page
@@ -3283,16 +3457,19 @@ class FletDesktopRendererWindow:
             }
         )
 
-    def _run_page_task(self, func: Callable[[], Awaitable[None]]) -> None:
+    def _run_page_task(self, func: Callable[[], Awaitable[None]]) -> ScheduledCallbackTask | None:
         if self._closed.is_set():
-            return
+            return None
         page = self._page
         if page is not None:
             run_task = getattr(page, "run_task", None)
             if callable(run_task):
-                self._track_scheduled_callback_task(run_task(func))
-                return
-        self._track_scheduled_callback_task(asyncio.create_task(func()))
+                task = run_task(func)
+                self._track_scheduled_callback_task(task)
+                return task if isinstance(task, (asyncio.Future, ConcurrentFuture)) else None
+        task = asyncio.create_task(func())
+        self._track_scheduled_callback_task(task)
+        return task
 
     async def _emit_overlay_event(self, payload: dict[str, object]) -> None:
         if self._closed.is_set():

--- a/src/puripuly_heart/ui/desktop_overlay.py
+++ b/src/puripuly_heart/ui/desktop_overlay.py
@@ -2735,6 +2735,10 @@ class FletDesktopRendererWindow:
         locked = self._interaction_mode == _DESKTOP_INTERACTION_MODE_PASS_THROUGH
         window = page.window
         window.ignore_mouse_events = locked
+        # Re-assert topmost after locking to prevent fullscreen windowed games
+        # (e.g. VRChat) from stealing z-order. See: #12
+        if locked:
+            window.always_on_top = True
 
     def _reveal_window_if_supported(self) -> None:
         page = self._page

--- a/src/puripuly_heart/ui/desktop_window_zorder.py
+++ b/src/puripuly_heart/ui/desktop_window_zorder.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import asyncio
+import ctypes
+import os
+from collections.abc import Awaitable, Callable
+from ctypes import wintypes
+from dataclasses import dataclass
+from typing import Protocol
+
+_GWL_EXSTYLE = -20
+_GW_OWNER = 4
+_HWND_TOPMOST = -1
+_SWP_NOSIZE = 0x0001
+_SWP_NOMOVE = 0x0002
+_SWP_NOACTIVATE = 0x0010
+_SWP_ASYNCWINDOWPOS = 0x4000
+_WS_EX_TOPMOST = 0x00000008
+_WS_EX_TRANSPARENT = 0x00000020
+
+
+@dataclass(frozen=True, slots=True)
+class WindowZOrderResult:
+    applied: bool
+    reason: str
+    win32_error: int | None = None
+    click_through_confirmed: bool = False
+    topmost_style_present: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class WindowEnumerationResult:
+    windows: tuple[int, ...]
+    win32_error: int | None = None
+
+
+class WindowZOrderPort(Protocol):
+    def bind_process(self, pid: int) -> None: ...
+
+    async def reassert_topmost_after_click_through(self) -> WindowZOrderResult: ...
+
+    def close(self) -> None: ...
+
+
+class Win32WindowApi(Protocol):
+    def top_level_windows_for_process(self, pid: int) -> WindowEnumerationResult: ...
+
+    def is_window(self, hwnd: int) -> bool: ...
+
+    def process_id(self, hwnd: int) -> int | None: ...
+
+    def extended_style(self, hwnd: int) -> int: ...
+
+    def set_topmost_no_activate(self, hwnd: int) -> tuple[bool, int | None]: ...
+
+
+class NoopWindowZOrderPort:
+    def bind_process(self, pid: int) -> None:
+        return None
+
+    async def reassert_topmost_after_click_through(self) -> WindowZOrderResult:
+        return WindowZOrderResult(applied=False, reason="unsupported_platform")
+
+    def close(self) -> None:
+        return None
+
+
+class WindowsWindowZOrderPort:
+    def __init__(
+        self,
+        *,
+        api: Win32WindowApi | None = None,
+        timeout_s: float = 0.5,
+        poll_interval_s: float = 0.01,
+        sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    ) -> None:
+        self._api = api or _CtypesWin32WindowApi()
+        self._timeout_s = max(0.0, float(timeout_s))
+        self._poll_interval_s = max(0.001, float(poll_interval_s))
+        self._sleep = sleep
+        self._pid: int | None = None
+        self._binding_generation = 0
+        self._closed = False
+
+    def bind_process(self, pid: int) -> None:
+        if self._closed:
+            return
+        self._pid = int(pid) if int(pid) > 0 else None
+        self._binding_generation += 1
+
+    async def reassert_topmost_after_click_through(self) -> WindowZOrderResult:
+        pid = self._pid
+        generation = self._binding_generation
+        if self._closed:
+            return WindowZOrderResult(applied=False, reason="closed")
+        if pid is None:
+            return WindowZOrderResult(applied=False, reason="process_unbound")
+
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self._timeout_s
+        hwnd: int | None = None
+        fallback_hwnd: int | None = None
+        click_through_confirmed = False
+        ambiguous = False
+
+        while True:
+            if not self._binding_is_current(pid, generation):
+                return WindowZOrderResult(applied=False, reason="binding_changed")
+            enumeration = self._api.top_level_windows_for_process(pid)
+            if enumeration.win32_error is not None:
+                return WindowZOrderResult(
+                    applied=False,
+                    reason="enum_windows_failed",
+                    win32_error=enumeration.win32_error,
+                )
+            candidates = tuple(
+                candidate
+                for candidate in enumeration.windows
+                if self._window_belongs_to_process(candidate, pid)
+            )
+            transparent_candidates = tuple(
+                candidate
+                for candidate in candidates
+                if self._api.extended_style(candidate) & _WS_EX_TRANSPARENT
+            )
+            ambiguous = len(transparent_candidates) > 1 or (
+                not transparent_candidates and len(candidates) > 1
+            )
+            if len(transparent_candidates) == 1:
+                hwnd = transparent_candidates[0]
+                click_through_confirmed = True
+                break
+            fallback_hwnd = candidates[0] if len(candidates) == 1 else None
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                break
+            await self._sleep(min(self._poll_interval_s, remaining))
+
+        if hwnd is None and ambiguous:
+            return WindowZOrderResult(applied=False, reason="ambiguous_window")
+        hwnd = hwnd or fallback_hwnd
+        if hwnd is None:
+            return WindowZOrderResult(applied=False, reason="window_not_found")
+        if not self._binding_is_current(pid, generation):
+            return WindowZOrderResult(applied=False, reason="binding_changed")
+        if not self._window_belongs_to_process(hwnd, pid):
+            return WindowZOrderResult(applied=False, reason="window_changed")
+
+        applied, win32_error = self._api.set_topmost_no_activate(hwnd)
+        if not applied:
+            return WindowZOrderResult(
+                applied=False,
+                reason="set_window_pos_failed",
+                win32_error=win32_error,
+                click_through_confirmed=click_through_confirmed,
+            )
+
+        deadline = loop.time() + self._timeout_s
+        while True:
+            if not self._binding_is_current(pid, generation):
+                return WindowZOrderResult(applied=False, reason="binding_changed")
+            if not self._window_belongs_to_process(hwnd, pid):
+                return WindowZOrderResult(applied=False, reason="window_changed")
+            if self._api.extended_style(hwnd) & _WS_EX_TOPMOST:
+                return WindowZOrderResult(
+                    applied=True,
+                    reason="applied" if click_through_confirmed else "applied_unconfirmed",
+                    click_through_confirmed=click_through_confirmed,
+                    topmost_style_present=True,
+                )
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return WindowZOrderResult(
+                    applied=False,
+                    reason="topmost_style_missing",
+                    click_through_confirmed=click_through_confirmed,
+                )
+            await self._sleep(min(self._poll_interval_s, remaining))
+
+    def close(self) -> None:
+        self._closed = True
+        self._pid = None
+        self._binding_generation += 1
+
+    def _binding_is_current(self, pid: int, generation: int) -> bool:
+        return not self._closed and self._pid == pid and self._binding_generation == generation
+
+    def _window_belongs_to_process(self, hwnd: int, pid: int) -> bool:
+        return self._api.is_window(hwnd) and self._api.process_id(hwnd) == pid
+
+
+class _CtypesWin32WindowApi:
+    def __init__(self) -> None:
+        self._user32 = ctypes.WinDLL("user32", use_last_error=True)
+        self._enum_proc_type = ctypes.WINFUNCTYPE(
+            wintypes.BOOL,
+            wintypes.HWND,
+            wintypes.LPARAM,
+        )
+        self._user32.EnumWindows.argtypes = [self._enum_proc_type, wintypes.LPARAM]
+        self._user32.EnumWindows.restype = wintypes.BOOL
+        self._user32.GetWindowThreadProcessId.argtypes = [
+            wintypes.HWND,
+            ctypes.POINTER(wintypes.DWORD),
+        ]
+        self._user32.GetWindowThreadProcessId.restype = wintypes.DWORD
+        self._user32.IsWindowVisible.argtypes = [wintypes.HWND]
+        self._user32.IsWindowVisible.restype = wintypes.BOOL
+        self._user32.GetWindow.argtypes = [wintypes.HWND, wintypes.UINT]
+        self._user32.GetWindow.restype = wintypes.HWND
+        self._user32.IsWindow.argtypes = [wintypes.HWND]
+        self._user32.IsWindow.restype = wintypes.BOOL
+        self._user32.GetWindowLongPtrW.argtypes = [wintypes.HWND, ctypes.c_int]
+        self._user32.GetWindowLongPtrW.restype = ctypes.c_ssize_t
+        self._user32.SetWindowPos.argtypes = [
+            wintypes.HWND,
+            wintypes.HWND,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+            wintypes.UINT,
+        ]
+        self._user32.SetWindowPos.restype = wintypes.BOOL
+
+    def top_level_windows_for_process(self, pid: int) -> WindowEnumerationResult:
+        windows: list[int] = []
+
+        def collect(hwnd: int, _lparam: int) -> bool:
+            if self.process_id(hwnd) != pid:
+                return True
+            if not self._user32.IsWindowVisible(hwnd):
+                return True
+            if self._user32.GetWindow(hwnd, _GW_OWNER):
+                return True
+            windows.append(int(hwnd))
+            return True
+
+        callback = self._enum_proc_type(collect)
+        ctypes.set_last_error(0)
+        if not self._user32.EnumWindows(callback, 0):
+            return WindowEnumerationResult(
+                windows=(),
+                win32_error=ctypes.get_last_error(),
+            )
+        return WindowEnumerationResult(windows=tuple(windows))
+
+    def is_window(self, hwnd: int) -> bool:
+        return bool(self._user32.IsWindow(hwnd))
+
+    def process_id(self, hwnd: int) -> int | None:
+        process_id = wintypes.DWORD()
+        if not self._user32.GetWindowThreadProcessId(hwnd, ctypes.byref(process_id)):
+            return None
+        return int(process_id.value)
+
+    def extended_style(self, hwnd: int) -> int:
+        return int(self._user32.GetWindowLongPtrW(hwnd, _GWL_EXSTYLE))
+
+    def set_topmost_no_activate(self, hwnd: int) -> tuple[bool, int | None]:
+        ctypes.set_last_error(0)
+        applied = bool(
+            self._user32.SetWindowPos(
+                hwnd,
+                wintypes.HWND(_HWND_TOPMOST),
+                0,
+                0,
+                0,
+                0,
+                _SWP_NOMOVE | _SWP_NOSIZE | _SWP_NOACTIVATE | _SWP_ASYNCWINDOWPOS,
+            )
+        )
+        return applied, None if applied else ctypes.get_last_error()
+
+
+def create_window_z_order_port() -> WindowZOrderPort:
+    if os.name != "nt":
+        return NoopWindowZOrderPort()
+    return WindowsWindowZOrderPort()

--- a/tests/ui/test_desktop_overlay_renderer.py
+++ b/tests/ui/test_desktop_overlay_renderer.py
@@ -23,7 +23,7 @@ from puripuly_heart.core.overlay.protocol import (
     OverlayPresentationCalibration,
     OverlayPresentationSnapshot,
 )
-from puripuly_heart.ui import desktop_overlay
+from puripuly_heart.ui import desktop_overlay, desktop_window_zorder
 from puripuly_heart.ui.fonts import assets_dir
 
 
@@ -1165,6 +1165,43 @@ class RecordingLifecycleSink:
         self.events.append(dict(event))
 
 
+class RecordingWindowZOrderPort:
+    def __init__(
+        self,
+        *,
+        on_reassert: Any | None = None,
+        result: desktop_window_zorder.WindowZOrderResult | None = None,
+        error: Exception | None = None,
+    ) -> None:
+        self.on_reassert = on_reassert
+        self.result = result or desktop_window_zorder.WindowZOrderResult(
+            applied=True,
+            reason="applied",
+            click_through_confirmed=True,
+            topmost_style_present=True,
+        )
+        self.error = error
+        self.bound_pids: list[int] = []
+        self.reassert_calls = 0
+        self.close_calls = 0
+
+    def bind_process(self, pid: int) -> None:
+        self.bound_pids.append(pid)
+
+    async def reassert_topmost_after_click_through(
+        self,
+    ) -> desktop_window_zorder.WindowZOrderResult:
+        self.reassert_calls += 1
+        if self.on_reassert is not None:
+            self.on_reassert()
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
 class RecordingWebSocket:
     def __init__(self) -> None:
         self.sent_messages: list[dict[str, object]] = []
@@ -1276,6 +1313,7 @@ class FakeFletPage:
         )
 
     def run_task(self, func: Any, *args: object, **kwargs: object) -> asyncio.Task[object]:
+        assert asyncio.iscoroutinefunction(func)
         self.run_task_calls += 1
         result = func(*args, **kwargs)
         if inspect.isawaitable(result):
@@ -2039,7 +2077,6 @@ async def test_desktop_overlay_preview_post_start_updates_retain_caption_surface
         await window.dispatch_runtime_control(
             {"command": "set_interaction_mode", "mode": "pass_through"}
         )
-        protected_writes = len(app.page.window.protected_writes)
         window._on_preview_keyboard_event(type("PreviewKeyEvent", (), {"key": "e"})())
         await asyncio.gather(*app.page.tasks)
 
@@ -2152,6 +2189,67 @@ async def test_default_flet_app_runner_starts_hidden_to_prevent_startup_flash(
 
 
 @pytest.mark.asyncio
+async def test_flet_launcher_patch_reports_started_process_pid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import flet_desktop
+
+    started_processes: list[tuple[int, str | None]] = []
+    fake_process = type("FakeProcess", (), {"pid": 4321})()
+
+    async def fake_hidden_launcher(
+        page_url: str,
+        assets_dir: str | None,
+        hidden: bool,
+    ) -> tuple[object, str]:
+        assert (page_url, assets_dir, hidden) == ("flet://desktop-overlay", "assets", True)
+        return fake_process, "pid-file"
+
+    monkeypatch.setattr(
+        desktop_overlay,
+        "_open_flet_view_hidden_without_startup_flash",
+        fake_hidden_launcher,
+    )
+
+    with desktop_overlay._patch_flet_view_hidden_launcher(
+        on_process_started=lambda pid, pid_file: started_processes.append((pid, pid_file))
+    ):
+        process, pid_file = await flet_desktop.open_flet_view_async(
+            "flet://desktop-overlay",
+            "assets",
+            True,
+        )
+
+    assert process is fake_process
+    assert pid_file == "pid-file"
+    assert started_processes == [(4321, "pid-file")]
+
+
+def test_desktop_overlay_prefers_flet_pid_file_for_window_binding(tmp_path: Path) -> None:
+    pid_file = tmp_path / "flet.pid"
+    pid_file.write_text("5678", encoding="utf-8")
+    port = RecordingWindowZOrderPort()
+    window = desktop_overlay.FletDesktopRendererWindow(
+        app_runner=FakeFletApp().run,
+        window_z_order_port=port,
+        window_process_info_provider=lambda: None,
+    )
+
+    window._record_flet_process(4321, str(pid_file))
+    window._bind_window_z_order_process()
+
+    assert port.bound_pids == [5678]
+
+
+def test_desktop_overlay_requires_process_provider_for_custom_runner_and_zorder() -> None:
+    with pytest.raises(ValueError, match="window_process_info_provider"):
+        desktop_overlay.FletDesktopRendererWindow(
+            app_runner=FakeFletApp().run,
+            window_z_order_port=RecordingWindowZOrderPort(),
+        )
+
+
+@pytest.mark.asyncio
 async def test_hidden_flet_view_launcher_uses_windows_startup_hide_before_flet_env_hide(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -2249,6 +2347,196 @@ async def test_desktop_overlay_reveals_first_window_update_after_chrome_bounds_a
         }
     finally:
         await window.close()
+
+
+@pytest.mark.asyncio
+async def test_desktop_overlay_reasserts_topmost_after_locked_render_update() -> None:
+    app = FakeFletApp()
+    observations: list[tuple[bool | None, int, dict[str, object]]] = []
+    port = RecordingWindowZOrderPort(
+        on_reassert=lambda: observations.append(
+            (
+                app.page.window.ignore_mouse_events,
+                app.page.update_calls,
+                dict(app.page.render_snapshots[-1]),
+            )
+        )
+    )
+    window = desktop_overlay.FletDesktopRendererWindow(
+        app_runner=app.run,
+        event_sink=RecordingLifecycleSink().emit,
+        locale="en",
+        window_z_order_port=port,
+        window_process_info_provider=lambda: (4321, None),
+    )
+
+    try:
+        await window.start(OverlayPresentationSnapshot(revision=1, blocks=[]))
+        updates_before_lock = app.page.update_calls
+
+        await window.dispatch_runtime_control(
+            {"command": "set_interaction_mode", "mode": "pass_through"}
+        )
+        z_order_task = window._window_z_order_task
+        if z_order_task is not None:
+            await z_order_task
+        await window.dispatch_runtime_control(
+            {"command": "set_interaction_mode", "mode": "pass_through"}
+        )
+        await window.dispatch_runtime_control({"command": "set_interaction_mode", "mode": "edit"})
+
+        assert observations == [
+            (
+                True,
+                updates_before_lock + 1,
+                {
+                    "ignore_mouse_events": True,
+                    "texts": set(),
+                    "has_drag_area": True,
+                    "card_count": 0,
+                },
+            )
+        ]
+        assert port.reassert_calls == 1
+    finally:
+        await window.close()
+
+    assert port.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_desktop_overlay_keeps_locked_state_when_zorder_port_fails(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    app = FakeFletApp()
+    sink = RecordingLifecycleSink()
+    port = RecordingWindowZOrderPort(error=RuntimeError("z-order failed"))
+    window = desktop_overlay.FletDesktopRendererWindow(
+        app_runner=app.run,
+        event_sink=sink.emit,
+        locale="en",
+        window_z_order_port=port,
+        window_process_info_provider=lambda: (4321, None),
+    )
+
+    try:
+        await window.start(OverlayPresentationSnapshot(revision=1, blocks=[]))
+
+        with caplog.at_level(logging.WARNING):
+            await window.dispatch_runtime_control(
+                {"command": "set_interaction_mode", "mode": "pass_through"}
+            )
+            z_order_task = window._window_z_order_task
+            if z_order_task is not None:
+                await z_order_task
+
+        assert app.page.window.ignore_mouse_events is True
+        assert sink.events[-1] == {
+            "type": "overlay_event",
+            "payload": {"event": "interaction_mode_changed", "mode": "pass_through"},
+        }
+        assert "reason=port_error exception_type=RuntimeError" in caplog.text
+    finally:
+        await window.close()
+
+
+@pytest.mark.asyncio
+async def test_desktop_overlay_cancels_stale_zorder_before_edit_event() -> None:
+    class BlockingWindowZOrderPort(RecordingWindowZOrderPort):
+        def __init__(self) -> None:
+            super().__init__()
+            self.started = asyncio.Event()
+            self.cancelled = asyncio.Event()
+
+        async def reassert_topmost_after_click_through(
+            self,
+        ) -> desktop_window_zorder.WindowZOrderResult:
+            self.reassert_calls += 1
+            self.started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                self.cancelled.set()
+                raise
+
+    app = FakeFletApp()
+    sink = RecordingLifecycleSink()
+    port = BlockingWindowZOrderPort()
+    window = desktop_overlay.FletDesktopRendererWindow(
+        app_runner=app.run,
+        event_sink=sink.emit,
+        locale="en",
+        window_z_order_port=port,
+        window_process_info_provider=lambda: (4321, None),
+    )
+
+    try:
+        await window.start(OverlayPresentationSnapshot(revision=1, blocks=[]))
+        await window.dispatch_runtime_control(
+            {"command": "set_interaction_mode", "mode": "pass_through"}
+        )
+        await port.started.wait()
+        await window.dispatch_runtime_control({"command": "set_interaction_mode", "mode": "edit"})
+
+        assert port.cancelled.is_set()
+        assert window._window_z_order_task is None
+        assert app.page.window.ignore_mouse_events is False
+        assert [event["payload"]["mode"] for event in sink.events] == [
+            "pass_through",
+            "edit",
+        ]
+    finally:
+        await window.close()
+
+
+@pytest.mark.asyncio
+async def test_desktop_overlay_rejects_late_page_after_close() -> None:
+    app = FakeFletApp()
+    port = RecordingWindowZOrderPort()
+    window = desktop_overlay.FletDesktopRendererWindow(
+        app_runner=app.run,
+        window_z_order_port=port,
+        window_process_info_provider=lambda: (4321, None),
+    )
+
+    await window.close()
+    window._handle_page(app.page)
+
+    assert window._page is None
+    assert app.page.window.close_calls == 1
+    assert port.bound_pids == []
+    assert port.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_desktop_overlay_drops_mode_transition_queued_before_close() -> None:
+    app = FakeFletApp()
+    sink = RecordingLifecycleSink()
+    port = RecordingWindowZOrderPort()
+    window = desktop_overlay.FletDesktopRendererWindow(
+        app_runner=app.run,
+        event_sink=sink.emit,
+        window_z_order_port=port,
+        window_process_info_provider=lambda: (4321, None),
+    )
+    await window.start(OverlayPresentationSnapshot(revision=1, blocks=[]))
+    updates_before_close = app.page.update_calls
+
+    await window._interaction_mode_lock.acquire()
+    transition_task = asyncio.create_task(
+        window.dispatch_runtime_control({"command": "set_interaction_mode", "mode": "pass_through"})
+    )
+    await asyncio.sleep(0)
+    close_task = asyncio.create_task(window.close())
+    await asyncio.sleep(0)
+    window._interaction_mode_lock.release()
+    await asyncio.gather(transition_task, close_task)
+
+    assert app.page.update_calls == updates_before_close
+    assert sink.events == []
+    assert window._window_z_order_task is None
+    assert port.reassert_calls == 0
+    assert port.close_calls == 1
 
 
 @pytest.mark.asyncio
@@ -3156,7 +3444,6 @@ async def test_desktop_overlay_post_start_paths_update_retained_controls_in_plac
 
         assert app.page.window.ignore_mouse_events is True
         assert model.caption_surface.visible is False
-        protected_writes = len(app.page.window.protected_writes)
         await window.dispatch_runtime_control({"command": "set_interaction_mode", "mode": "edit"})
         assert app.page.window.ignore_mouse_events is False
         assert identities == (

--- a/tests/ui/test_desktop_overlay_renderer.py
+++ b/tests/ui/test_desktop_overlay_renderer.py
@@ -2039,6 +2039,7 @@ async def test_desktop_overlay_preview_post_start_updates_retain_caption_surface
         await window.dispatch_runtime_control(
             {"command": "set_interaction_mode", "mode": "pass_through"}
         )
+        protected_writes = len(app.page.window.protected_writes)
         window._on_preview_keyboard_event(type("PreviewKeyEvent", (), {"key": "e"})())
         await asyncio.gather(*app.page.tasks)
 
@@ -3155,6 +3156,7 @@ async def test_desktop_overlay_post_start_paths_update_retained_controls_in_plac
 
         assert app.page.window.ignore_mouse_events is True
         assert model.caption_surface.visible is False
+        protected_writes = len(app.page.window.protected_writes)
         await window.dispatch_runtime_control({"command": "set_interaction_mode", "mode": "edit"})
         assert app.page.window.ignore_mouse_events is False
         assert identities == (

--- a/tests/ui/test_desktop_window_zorder.py
+++ b/tests/ui/test_desktop_window_zorder.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+import pytest
+
+from puripuly_heart.ui import desktop_window_zorder
+
+
+class FakeWin32WindowApi:
+    def __init__(
+        self,
+        *,
+        windows: tuple[int, ...] = (101,),
+        styles: tuple[int, ...] = (desktop_window_zorder._WS_EX_TRANSPARENT,),
+        set_result: tuple[bool, int | None] = (True, None),
+        enum_error: int | None = None,
+    ) -> None:
+        self.windows = windows
+        self.styles = list(styles)
+        self.current_style = self.styles[-1] if self.styles else 0
+        self.set_result = set_result
+        self.enum_error = enum_error
+        self.window_queries: list[int] = []
+        self.set_calls: list[int] = []
+        self.pid = 4321
+
+    def top_level_windows_for_process(
+        self, pid: int
+    ) -> desktop_window_zorder.WindowEnumerationResult:
+        self.window_queries.append(pid)
+        return desktop_window_zorder.WindowEnumerationResult(
+            windows=self.windows,
+            win32_error=self.enum_error,
+        )
+
+    def is_window(self, hwnd: int) -> bool:
+        return hwnd in self.windows
+
+    def process_id(self, hwnd: int) -> int | None:
+        return self.pid if hwnd in self.windows else None
+
+    def extended_style(self, hwnd: int) -> int:
+        assert hwnd in self.windows
+        if self.styles:
+            self.current_style = self.styles.pop(0)
+        return self.current_style
+
+    def set_topmost_no_activate(self, hwnd: int) -> tuple[bool, int | None]:
+        self.set_calls.append(hwnd)
+        if self.set_result[0]:
+            self.current_style |= desktop_window_zorder._WS_EX_TOPMOST
+        return self.set_result
+
+
+@pytest.mark.asyncio
+async def test_windows_zorder_port_reasserts_bound_process_window_after_click_through() -> None:
+    api = FakeWin32WindowApi()
+    port = desktop_window_zorder.WindowsWindowZOrderPort(api=api)
+    port.bind_process(4321)
+
+    result = await port.reassert_topmost_after_click_through()
+
+    assert result == desktop_window_zorder.WindowZOrderResult(
+        applied=True,
+        reason="applied",
+        click_through_confirmed=True,
+        topmost_style_present=True,
+    )
+    assert api.window_queries == [4321]
+    assert api.set_calls == [101]
+
+
+@pytest.mark.asyncio
+async def test_windows_zorder_port_waits_for_click_through_before_reasserting() -> None:
+    api = FakeWin32WindowApi(
+        styles=(0, 0, desktop_window_zorder._WS_EX_TRANSPARENT),
+    )
+    sleeps: list[float] = []
+
+    async def record_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    port = desktop_window_zorder.WindowsWindowZOrderPort(
+        api=api,
+        timeout_s=0.5,
+        poll_interval_s=0.01,
+        sleep=record_sleep,
+    )
+    port.bind_process(4321)
+
+    result = await port.reassert_topmost_after_click_through()
+
+    assert result.applied is True
+    assert result.click_through_confirmed is True
+    assert len(sleeps) == 2
+    assert api.set_calls == [101]
+
+
+@pytest.mark.asyncio
+async def test_windows_zorder_port_reasserts_best_effort_when_click_through_is_unconfirmed() -> (
+    None
+):
+    api = FakeWin32WindowApi(styles=(0,))
+    port = desktop_window_zorder.WindowsWindowZOrderPort(api=api, timeout_s=0)
+    port.bind_process(4321)
+
+    result = await port.reassert_topmost_after_click_through()
+
+    assert result.applied is True
+    assert result.reason == "applied_unconfirmed"
+    assert result.click_through_confirmed is False
+    assert api.set_calls == [101]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("windows", "expected_reason"),
+    [
+        ((), "window_not_found"),
+        ((101, 102), "ambiguous_window"),
+    ],
+)
+async def test_windows_zorder_port_rejects_missing_or_ambiguous_windows(
+    windows: tuple[int, ...],
+    expected_reason: str,
+) -> None:
+    api = FakeWin32WindowApi(windows=windows)
+    port = desktop_window_zorder.WindowsWindowZOrderPort(api=api, timeout_s=0)
+    port.bind_process(4321)
+
+    result = await port.reassert_topmost_after_click_through()
+
+    assert result.applied is False
+    assert result.reason == expected_reason
+    assert api.set_calls == []
+
+
+@pytest.mark.asyncio
+async def test_windows_zorder_port_retries_transient_ambiguity() -> None:
+    class TransientAmbiguityApi(FakeWin32WindowApi):
+        def __init__(self) -> None:
+            super().__init__(windows=(101, 102))
+            self.batches = [(101, 102), (101,)]
+
+        def top_level_windows_for_process(
+            self, pid: int
+        ) -> desktop_window_zorder.WindowEnumerationResult:
+            self.window_queries.append(pid)
+            self.windows = self.batches.pop(0)
+            return desktop_window_zorder.WindowEnumerationResult(windows=self.windows)
+
+        def extended_style(self, hwnd: int) -> int:
+            return desktop_window_zorder._WS_EX_TRANSPARENT | (
+                desktop_window_zorder._WS_EX_TOPMOST if self.set_calls else 0
+            )
+
+    api = TransientAmbiguityApi()
+    port = desktop_window_zorder.WindowsWindowZOrderPort(api=api)
+    port.bind_process(4321)
+
+    result = await port.reassert_topmost_after_click_through()
+
+    assert result.applied is True
+    assert api.window_queries == [4321, 4321]
+    assert api.set_calls == [101]
+
+
+@pytest.mark.asyncio
+async def test_windows_zorder_port_reports_window_enumeration_failure() -> None:
+    api = FakeWin32WindowApi(windows=(), enum_error=5)
+    port = desktop_window_zorder.WindowsWindowZOrderPort(api=api)
+    port.bind_process(4321)
+
+    result = await port.reassert_topmost_after_click_through()
+
+    assert result.applied is False
+    assert result.reason == "enum_windows_failed"
+    assert result.win32_error == 5
+
+
+@pytest.mark.asyncio
+async def test_windows_zorder_port_revalidates_process_before_mutation() -> None:
+    class ReusedWindowApi(FakeWin32WindowApi):
+        def __init__(self) -> None:
+            super().__init__()
+            self.process_queries = 0
+
+        def process_id(self, hwnd: int) -> int | None:
+            self.process_queries += 1
+            return 4321 if self.process_queries == 1 else 9999
+
+    api = ReusedWindowApi()
+    port = desktop_window_zorder.WindowsWindowZOrderPort(api=api)
+    port.bind_process(4321)
+
+    result = await port.reassert_topmost_after_click_through()
+
+    assert result.applied is False
+    assert result.reason == "window_changed"
+    assert api.set_calls == []
+
+
+@pytest.mark.asyncio
+async def test_windows_zorder_port_stops_when_closed_during_polling() -> None:
+    api = FakeWin32WindowApi(styles=(0,))
+    port: desktop_window_zorder.WindowsWindowZOrderPort
+
+    async def close_during_sleep(_delay: float) -> None:
+        port.close()
+
+    port = desktop_window_zorder.WindowsWindowZOrderPort(
+        api=api,
+        sleep=close_during_sleep,
+    )
+    port.bind_process(4321)
+
+    result = await port.reassert_topmost_after_click_through()
+
+    assert result.applied is False
+    assert result.reason == "binding_changed"
+    assert api.set_calls == []
+
+
+@pytest.mark.asyncio
+async def test_windows_zorder_port_reports_set_window_pos_failure() -> None:
+    api = FakeWin32WindowApi(set_result=(False, 5))
+    port = desktop_window_zorder.WindowsWindowZOrderPort(api=api)
+    port.bind_process(4321)
+
+    result = await port.reassert_topmost_after_click_through()
+
+    assert result.applied is False
+    assert result.reason == "set_window_pos_failed"
+    assert result.win32_error == 5
+
+
+@pytest.mark.asyncio
+async def test_windows_zorder_port_rejects_missing_topmost_style_after_success() -> None:
+    class MissingTopmostApi(FakeWin32WindowApi):
+        def set_topmost_no_activate(self, hwnd: int) -> tuple[bool, int | None]:
+            self.set_calls.append(hwnd)
+            return True, None
+
+    api = MissingTopmostApi()
+    port = desktop_window_zorder.WindowsWindowZOrderPort(api=api)
+    port.bind_process(4321)
+
+    result = await port.reassert_topmost_after_click_through()
+
+    assert result.applied is False
+    assert result.reason == "topmost_style_missing"
+    assert api.set_calls == [101]
+
+
+@pytest.mark.asyncio
+async def test_windows_zorder_port_polls_async_topmost_postcondition() -> None:
+    class DelayedTopmostApi(FakeWin32WindowApi):
+        def set_topmost_no_activate(self, hwnd: int) -> tuple[bool, int | None]:
+            self.set_calls.append(hwnd)
+            return True, None
+
+    api = DelayedTopmostApi(
+        styles=(
+            desktop_window_zorder._WS_EX_TRANSPARENT,
+            desktop_window_zorder._WS_EX_TRANSPARENT,
+            desktop_window_zorder._WS_EX_TRANSPARENT | desktop_window_zorder._WS_EX_TOPMOST,
+        )
+    )
+    sleeps: list[float] = []
+
+    async def record_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    port = desktop_window_zorder.WindowsWindowZOrderPort(api=api, sleep=record_sleep)
+    port.bind_process(4321)
+
+    result = await port.reassert_topmost_after_click_through()
+
+    assert result.applied is True
+    assert result.topmost_style_present is True
+    assert len(sleeps) == 1
+
+
+@pytest.mark.asyncio
+async def test_windows_zorder_port_close_discards_process_binding() -> None:
+    api = FakeWin32WindowApi()
+    port = desktop_window_zorder.WindowsWindowZOrderPort(api=api)
+    port.bind_process(4321)
+    port.close()
+
+    result = await port.reassert_topmost_after_click_through()
+
+    assert result.applied is False
+    assert result.reason == "closed"
+    assert api.window_queries == []
+
+
+@pytest.mark.asyncio
+async def test_noop_zorder_port_is_immediate_and_unsupported() -> None:
+    port = desktop_window_zorder.NoopWindowZOrderPort()
+    port.bind_process(4321)
+
+    result = await port.reassert_topmost_after_click_through()
+
+    assert result.applied is False
+    assert result.reason == "unsupported_platform"
+
+
+def test_ctypes_win32_api_sets_topmost_without_moving_sizing_or_activating(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[object, ...]] = []
+
+    class FakeUser32:
+        def SetWindowPos(self, *args: object) -> int:
+            calls.append(args)
+            return 1
+
+    api = object.__new__(desktop_window_zorder._CtypesWin32WindowApi)
+    api._user32 = FakeUser32()
+    monkeypatch.setattr(
+        desktop_window_zorder.ctypes,
+        "set_last_error",
+        lambda _value: None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        desktop_window_zorder.ctypes,
+        "get_last_error",
+        lambda: 0,
+        raising=False,
+    )
+
+    result = api.set_topmost_no_activate(101)
+
+    assert result == (True, None)
+    assert len(calls) == 1
+    hwnd, insert_after, x, y, width, height, flags = calls[0]
+    assert hwnd == 101
+    assert (
+        insert_after.value
+        == desktop_window_zorder.wintypes.HWND(desktop_window_zorder._HWND_TOPMOST).value
+    )
+    assert (x, y, width, height) == (0, 0, 0, 0)
+    assert flags == (
+        desktop_window_zorder._SWP_NOMOVE
+        | desktop_window_zorder._SWP_NOSIZE
+        | desktop_window_zorder._SWP_NOACTIVATE
+        | desktop_window_zorder._SWP_ASYNCWINDOWPOS
+    )


### PR DESCRIPTION
## Problem

In fullscreen windowed mode (e.g. VRChat), pressing 'Lock' on the desktop overlay causes the window to disappear behind the game, making it unusable. Without locking, translation text conflicts with the 'Lock' button text.

Ref: #12

## Fix

Re-assert `window.always_on_top = True` in `_apply_interaction_window_chrome()` when switching to `pass_through` (locked) mode. This ensures the overlay maintains its topmost z-order after locking.

The `always_on_top` flag is set once at window creation, but Windows can demote the z-order when `ignore_mouse_events = True` is set, especially in fullscreen windowed mode.

## Why this is safe

- `always_on_top` is never set to `False` anywhere in the codebase — this change only re-asserts the existing value
- `_apply_interaction_window_chrome()` is called only on window creation and mode changes, not on every render
- The change is isolated to `desktop_overlay.py` — no impact on controller or settings

## Limitations

This fix re-asserts the Flet-level `always_on_top` flag, which maps to `WS_EX_TOPMOST` window style. Some fullscreen games may use more aggressive z-order management (e.g. `SetWindowPos` with `HWND_TOPMOST`) that can override this.

If this fix doesn't resolve the issue, I'm ready to implement a more aggressive approach using Windows API directly (`ctypes.windll.user32.SetWindowPos` with `HWND_TOPMOST` and `SWP_NOACTIVATE`) to forcefully bring the overlay to the top after locking.

## Tests

- Updated `protected_writes` assertions in `test_desktop_overlay_renderer.py` to account for the additional `always_on_top` write during lock
- All existing overlay tests pass

Also-by: mimo-pro

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 마우스 입력이 차단된 오버레이가 전체 화면 게임 위에서 항상 최상단에 유지되도록 개선했습니다.
  * 오버레이 잠금 및 편집 모드 전환 시 창 상태가 안정적으로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->