### PR TITLE
fix(stt): apply source-language changes to the live self backend

### DIFF
--- a/src/puripuly_heart/app/services/capture/self_capture_application.py
+++ b/src/puripuly_heart/app/services/capture/self_capture_application.py
@@ -134,6 +134,11 @@ class SelfCaptureApplicationOwner:
         self.state_sink(snapshot)
         self.project_availability(snapshot)
         self.restart_requested = False
+        if (
+            snapshot.failure_reason is not None
+            or snapshot.runtime_signature != config.runtime_signature
+        ):
+            raise RuntimeError("Self STT runtime did not apply the requested configuration")
 
     def project_availability(self, snapshot: SelfCaptureSessionSnapshot) -> bool:
         available = snapshot.provider_status is SelfCaptureProviderStatus.READY

--- a/src/puripuly_heart/app/services/gpu_runtime_interaction.py
+++ b/src/puripuly_heart/app/services/gpu_runtime_interaction.py
@@ -229,9 +229,7 @@ class GpuRuntimeInteractionOwner:
         self._discovery_failure_state = (
             "unsupported"
             if snapshot.gpu.phase == "unsupported"
-            else "discovery_failed"
-            if snapshot.gpu.phase == "failed"
-            else None
+            else "discovery_failed" if snapshot.gpu.phase == "failed" else None
         )
 
     def observe_provisioning(self, snapshot: LocalASRProvisioningSnapshot) -> None:

--- a/src/puripuly_heart/app/services/peer_application.py
+++ b/src/puripuly_heart/app/services/peer_application.py
@@ -577,10 +577,7 @@ class PeerApplicationOwner:
     def _should_hold_runtime_refresh(self, state: PeerApplicationState) -> bool:
         if not self.local_stt_requested(state):
             return False
-        if (
-            self._model_loading
-            and self._model_loading_generation == self._activation_generation
-        ):
+        if self._model_loading and self._model_loading_generation == self._activation_generation:
             return True
         return self._runtime_refresh_hold_generation == self._activation_generation
 

--- a/src/puripuly_heart/app/wiring/wiring_stt_factory.py
+++ b/src/puripuly_heart/app/wiring/wiring_stt_factory.py
@@ -423,9 +423,22 @@ def build_self_stt_runtime_signature(settings: AppSettings) -> tuple[object, ...
     )
 
 
+def _self_stt_provider_language_identity(settings: AppSettings) -> str | None:
+    if build_self_local_asr_transition_request(settings, trigger="runtime") is not None:
+        return None
+    return settings.languages.source_language
+
+
+def _self_stt_provider_model_identity(settings: AppSettings) -> str | None:
+    transition = build_self_local_asr_transition_request(settings, trigger="runtime")
+    return None if transition is None else transition.model_id
+
+
 def build_self_stt_provider_signature(settings: AppSettings) -> tuple[object, ...]:
     return (
         settings.provider.stt,
+        _self_stt_provider_language_identity(settings),
+        _self_stt_provider_model_identity(settings),
         (
             settings.deepgram_stt.model
             if settings.provider.stt == STTProviderName.DEEPGRAM

--- a/src/puripuly_heart/core/runtime/self_capture.py
+++ b/src/puripuly_heart/core/runtime/self_capture.py
@@ -277,7 +277,7 @@ class SelfCaptureSessionOwner:
             if self._is_superseded(generation):
                 return self.snapshot
             attachment_token = self._provider_attachment_token
-            if self._provider.is_ready(config):
+            if self._attached_provider_matches(config):
                 result_status = SelfCaptureProviderMutationStatus.APPLIED
                 failure_reason = None
             else:
@@ -577,7 +577,7 @@ class SelfCaptureSessionOwner:
             return
 
         attachment_token = self._provider_attachment_token
-        provider_was_ready = self._provider.is_ready(config)
+        provider_was_ready = self._attached_provider_matches(config)
         if not provider_was_ready:
             attachment_token = object()
             self._provider_status = SelfCaptureProviderStatus.PENDING
@@ -1071,6 +1071,12 @@ class SelfCaptureSessionOwner:
     def _retain_source(self, source: object) -> None:
         if not any(item is source for item in self._retired_sources):
             self._retired_sources.append(source)
+
+    def _attached_provider_matches(self, config: SelfCaptureSessionConfig) -> bool:
+        return (
+            self._provider.is_ready(config)
+            and self._provider_signature == config.provider_signature
+        )
 
     def _release_plan(
         self,

--- a/tests/app/test_self_capture_application_owner.py
+++ b/tests/app/test_self_capture_application_owner.py
@@ -38,11 +38,19 @@ async def test_replace_provider_propagates_updated_config_by_capture_activity(
 
         async def prepare_provider(self, config: object) -> object:
             calls.append(("prepare", config, {}))
-            return SimpleNamespace(provider_status=SelfCaptureProviderStatus.READY)
+            return SimpleNamespace(
+                provider_status=SelfCaptureProviderStatus.READY,
+                failure_reason=None,
+                runtime_signature=capture_config.runtime_signature,
+            )
 
         async def apply_intent(self, config: object, **kwargs: object) -> object:
             calls.append(("apply", config, kwargs))
-            return SimpleNamespace(provider_status=SelfCaptureProviderStatus.READY)
+            return SimpleNamespace(
+                provider_status=SelfCaptureProviderStatus.READY,
+                failure_reason=None,
+                runtime_signature=capture_config.runtime_signature,
+            )
 
     capture_owner = CaptureOwner()
     owner = SelfCaptureApplicationOwner(

--- a/tests/app/test_self_stt_source_language_runtime.py
+++ b/tests/app/test_self_stt_source_language_runtime.py
@@ -5,7 +5,6 @@ from collections.abc import Awaitable, Callable
 from typing import Any, Literal, cast
 
 import pytest
-
 from puripuly_heart.app.services.self_capture_application import (
     SelfCaptureApplicationOwner,
     SelfCaptureApplicationSettings,
@@ -17,6 +16,7 @@ from puripuly_heart.app.wiring_stt_factory import (
     build_self_stt_provider_signature,
     build_self_stt_runtime_signature,
 )
+
 from puripuly_heart.config.settings import AppSettings, STTProviderName
 from puripuly_heart.core.runtime.self_capture import SelfCaptureSessionOwner
 from puripuly_heart.core.self_capture import (
@@ -213,9 +213,7 @@ def test_local_cpu_auto_model_identity_changes_with_source_language() -> None:
     korean = _settings(STTProviderName.LOCAL_QWEN, "ko")
     japanese_qwen = _settings(STTProviderName.LOCAL_QWEN, "ja")
 
-    assert build_self_stt_provider_signature(english) != build_self_stt_provider_signature(
-        japanese
-    )
+    assert build_self_stt_provider_signature(english) != build_self_stt_provider_signature(japanese)
     assert build_self_stt_provider_signature(korean) == build_self_stt_provider_signature(
         japanese_qwen
     )
@@ -311,9 +309,9 @@ async def test_language_change_while_stt_off_prepares_new_language() -> None:
 
     assert snapshot.runtime_signature == build_self_stt_runtime_signature(japanese)
     assert started.runtime_signature == build_self_stt_runtime_signature(japanese)
-    assert [cast(Any, request).config.source_language for request, _start in provider.replace_calls][
-        -1
-    ] == "ja"
+    assert [
+        cast(Any, request).config.source_language for request, _start in provider.replace_calls
+    ][-1] == "ja"
     await owner.close()
 
 

--- a/tests/app/test_self_stt_source_language_runtime.py
+++ b/tests/app/test_self_stt_source_language_runtime.py
@@ -1,0 +1,357 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Any, Literal, cast
+
+import pytest
+
+from puripuly_heart.app.services.self_capture_application import (
+    SelfCaptureApplicationOwner,
+    SelfCaptureApplicationSettings,
+)
+from puripuly_heart.app.wiring_stt_factory import (
+    build_self_capture_session_config,
+    build_self_capture_vad_signature,
+    build_self_stt_provider_request,
+    build_self_stt_provider_signature,
+    build_self_stt_runtime_signature,
+)
+from puripuly_heart.config.settings import AppSettings, STTProviderName
+from puripuly_heart.core.runtime.self_capture import SelfCaptureSessionOwner
+from puripuly_heart.core.self_capture import (
+    SelfCaptureAdmission,
+    SelfCaptureAdmissionStatus,
+    SelfCaptureProviderMutation,
+    SelfCaptureProviderMutationStatus,
+    SelfCaptureProviderStatus,
+    SelfCaptureSessionConfig,
+    SelfCaptureSessionState,
+)
+
+_CLOUD_PROVIDERS = (
+    STTProviderName.DEEPGRAM,
+    STTProviderName.QWEN_ASR,
+    STTProviderName.SONIOX,
+)
+
+
+class _Admission:
+    async def admit(self, config: SelfCaptureSessionConfig) -> SelfCaptureAdmission:
+        _ = config
+        return SelfCaptureAdmission(SelfCaptureAdmissionStatus.ADMITTED)
+
+
+class _RecordingProvider:
+    def __init__(self) -> None:
+        self.ready = False
+        self.replace_result = SelfCaptureProviderMutation(SelfCaptureProviderMutationStatus.APPLIED)
+        self.handoff_result = SelfCaptureProviderMutation(SelfCaptureProviderMutationStatus.APPLIED)
+        self.replace_calls: list[tuple[object, bool]] = []
+        self.handoff_calls: list[tuple[object, bool]] = []
+        self.reconfigure_calls: list[object] = []
+        self.release_calls: list[tuple[str, float | None]] = []
+        self.start_calls = 0
+        self.warmup_calls = 0
+        self.terminal_failure_handler = None
+
+    def is_ready(self, config: SelfCaptureSessionConfig) -> bool:
+        _ = config
+        return self.ready
+
+    async def replace(
+        self,
+        request: object,
+        *,
+        start: bool,
+        on_terminal_failure: Callable[[Exception], Awaitable[None]],
+    ) -> SelfCaptureProviderMutation:
+        self.replace_calls.append((request, start))
+        self.terminal_failure_handler = on_terminal_failure
+        if self.replace_result.status is SelfCaptureProviderMutationStatus.APPLIED:
+            self.ready = True
+        return self.replace_result
+
+    async def handoff(
+        self,
+        request: object,
+        *,
+        start: bool,
+        on_terminal_failure: Callable[[Exception], Awaitable[None]],
+    ) -> SelfCaptureProviderMutation:
+        self.handoff_calls.append((request, start))
+        self.terminal_failure_handler = on_terminal_failure
+        return self.handoff_result
+
+    async def cancel_handoff(self) -> bool:
+        return True
+
+    async def start_ingress(self) -> None:
+        self.start_calls += 1
+
+    async def warmup(self) -> None:
+        self.warmup_calls += 1
+
+    async def reconfigure(self, session_options: object) -> None:
+        self.reconfigure_calls.append(session_options)
+
+    async def release(
+        self,
+        *,
+        mode: Literal["drain", "abort"],
+        release_backend_after: float | None = None,
+    ) -> None:
+        self.release_calls.append((mode, release_backend_after))
+        self.ready = False
+
+
+class _Source:
+    async def close(self) -> None:
+        return None
+
+
+class _Loop:
+    def __init__(self) -> None:
+        self.release = asyncio.Event()
+
+    async def run(self, **_kwargs: object) -> None:
+        await self.release.wait()
+
+
+def _settings(provider: STTProviderName, language: str) -> AppSettings:
+    settings = AppSettings()
+    settings.provider.stt = provider
+    settings.languages.source_language = language
+    return settings
+
+
+def _build_owner(
+    provider: _RecordingProvider,
+    settings_holder: dict[str, AppSettings],
+) -> SelfCaptureSessionOwner:
+    loop = _Loop()
+    return SelfCaptureSessionOwner(
+        admission=_Admission(),
+        provider=provider,
+        provider_request_factory=lambda _config, warmup: build_self_stt_provider_request(
+            settings_holder["settings"],
+            warmup=warmup,
+        ),
+        source_factory=lambda _config: _Source(),
+        vad_factory=lambda _config: object(),
+        run_audio_loop=loop.run,
+        vad_sink=object(),
+    )
+
+
+def _application_owner(
+    *,
+    session: SelfCaptureSessionOwner,
+    settings_holder: dict[str, AppSettings],
+) -> SelfCaptureApplicationOwner:
+    return SelfCaptureApplicationOwner(
+        settings_provider=lambda: SelfCaptureApplicationSettings(
+            config=build_self_capture_session_config(settings_holder["settings"]),
+            provider_id=settings_holder["settings"].provider.stt.value,
+            qwen_region=None,
+        ),
+        runtime_available=lambda: True,
+        capture_owner=lambda: session,
+        capture_owner_if_created=lambda: session,
+        persist_manual_fallback=lambda: True,
+        reset_local_pending=lambda: None,
+        clear_gpu_pending=lambda: None,
+        overlay_state_provider=lambda: "off",
+        mark_promo_eligible=lambda: None,
+        dashboard_enabled_sink=lambda _enabled: None,
+        dashboard_needs_key_sink=lambda _needs_key: None,
+        dashboard_needs_key=lambda _available: False,
+        state_sink=lambda _snapshot: None,
+        sync_effective_flags=lambda: None,
+        sync_local_notice=lambda: None,
+        log_basic=lambda _message: None,
+        log_detailed=lambda _message, _level: None,
+    )
+
+
+@pytest.mark.parametrize("provider", _CLOUD_PROVIDERS)
+def test_cloud_source_language_is_owned_by_self_provider_identity(
+    provider: STTProviderName,
+) -> None:
+    korean = _settings(provider, "ko")
+    japanese = _settings(provider, "ja")
+
+    assert build_self_stt_runtime_signature(korean) != build_self_stt_runtime_signature(japanese)
+    assert build_self_stt_provider_signature(korean) != build_self_stt_provider_signature(japanese)
+    assert build_self_capture_vad_signature(korean) == build_self_capture_vad_signature(japanese)
+    assert build_self_capture_session_config(korean).session_options is None
+    assert build_self_stt_provider_request(japanese).config.source_language == "ja"
+
+
+@pytest.mark.parametrize(
+    "provider",
+    (STTProviderName.LOCAL_QWEN, STTProviderName.LOCAL_QWEN_GPU),
+)
+def test_local_source_language_is_owned_by_session_options(
+    provider: STTProviderName,
+) -> None:
+    korean = _settings(provider, "ko")
+    japanese = _settings(provider, "ja")
+    korean_config = build_self_capture_session_config(korean)
+    japanese_config = build_self_capture_session_config(japanese)
+
+    assert build_self_stt_provider_signature(korean) == build_self_stt_provider_signature(japanese)
+    assert korean_config.session_options is not None
+    assert japanese_config.session_options is not None
+    assert korean_config.session_options != japanese_config.session_options
+    assert japanese_config.session_options.source_language == "ja"
+
+
+def test_local_cpu_auto_model_identity_changes_with_source_language() -> None:
+    english = _settings(STTProviderName.LOCAL_CPU_AUTO, "en")
+    japanese = _settings(STTProviderName.LOCAL_CPU_AUTO, "ja")
+    korean = _settings(STTProviderName.LOCAL_QWEN, "ko")
+    japanese_qwen = _settings(STTProviderName.LOCAL_QWEN, "ja")
+
+    assert build_self_stt_provider_signature(english) != build_self_stt_provider_signature(
+        japanese
+    )
+    assert build_self_stt_provider_signature(korean) == build_self_stt_provider_signature(
+        japanese_qwen
+    )
+
+
+def test_custom_vocabulary_still_changes_self_runtime_signature() -> None:
+    settings = _settings(STTProviderName.DEEPGRAM, "ko")
+    settings.stt.custom_vocabulary_enabled = True
+    settings.stt.custom_terms = {"ko": ["Puripuly"]}
+    before = build_self_stt_runtime_signature(settings)
+    provider_before = build_self_stt_provider_signature(settings)
+    settings.stt.custom_terms = {"ko": ["Puripuly", "VRChat"]}
+
+    assert build_self_stt_runtime_signature(settings) != before
+    assert build_self_stt_provider_signature(settings) == provider_before
+
+
+@pytest.mark.asyncio
+async def test_running_cloud_source_language_change_handoffs_new_backend() -> None:
+    korean = _settings(STTProviderName.DEEPGRAM, "ko")
+    japanese = _settings(STTProviderName.DEEPGRAM, "ja")
+    settings_holder = {"settings": korean}
+    provider = _RecordingProvider()
+    owner = _build_owner(provider, settings_holder)
+
+    await owner.apply_intent(build_self_capture_session_config(korean), enabled=True)
+    settings_holder["settings"] = japanese
+    snapshot = await owner.apply_intent(build_self_capture_session_config(japanese), enabled=True)
+
+    assert snapshot.state is SelfCaptureSessionState.RUNNING
+    assert snapshot.runtime_signature == build_self_stt_runtime_signature(japanese)
+    assert provider.reconfigure_calls == []
+    assert len(provider.handoff_calls) == 1
+    request, started = provider.handoff_calls[0]
+    assert started is True
+    assert request.config.source_language == "ja"
+    await owner.close()
+
+
+@pytest.mark.asyncio
+async def test_running_local_source_language_change_reconfigures_session_options() -> None:
+    korean = _settings(STTProviderName.LOCAL_QWEN, "ko")
+    japanese = _settings(STTProviderName.LOCAL_QWEN, "ja")
+    settings_holder = {"settings": korean}
+    provider = _RecordingProvider()
+    owner = _build_owner(provider, settings_holder)
+
+    await owner.apply_intent(build_self_capture_session_config(korean), enabled=True)
+    settings_holder["settings"] = japanese
+    snapshot = await owner.apply_intent(build_self_capture_session_config(japanese), enabled=True)
+
+    assert snapshot.state is SelfCaptureSessionState.RUNNING
+    assert snapshot.runtime_signature == build_self_stt_runtime_signature(japanese)
+    assert provider.handoff_calls == []
+    assert [options.source_language for options in provider.reconfigure_calls] == ["ja"]
+    await owner.close()
+
+
+@pytest.mark.asyncio
+async def test_running_local_cpu_auto_language_change_handoffs_when_model_changes() -> None:
+    english = _settings(STTProviderName.LOCAL_CPU_AUTO, "en")
+    japanese = _settings(STTProviderName.LOCAL_CPU_AUTO, "ja")
+    settings_holder = {"settings": english}
+    provider = _RecordingProvider()
+    owner = _build_owner(provider, settings_holder)
+
+    await owner.apply_intent(build_self_capture_session_config(english), enabled=True)
+    settings_holder["settings"] = japanese
+    snapshot = await owner.apply_intent(build_self_capture_session_config(japanese), enabled=True)
+
+    assert snapshot.state is SelfCaptureSessionState.RUNNING
+    assert snapshot.runtime_signature == build_self_stt_runtime_signature(japanese)
+    assert provider.reconfigure_calls == []
+    assert len(provider.handoff_calls) == 1
+    request, started = provider.handoff_calls[0]
+    assert started is True
+    assert request.config.source_language == "ja"
+    await owner.close()
+
+
+@pytest.mark.asyncio
+async def test_language_change_while_stt_off_prepares_new_language() -> None:
+    korean = _settings(STTProviderName.DEEPGRAM, "ko")
+    japanese = _settings(STTProviderName.DEEPGRAM, "ja")
+    settings_holder = {"settings": korean}
+    provider = _RecordingProvider()
+    owner = _build_owner(provider, settings_holder)
+
+    await owner.prepare_provider(build_self_capture_session_config(korean))
+    settings_holder["settings"] = japanese
+    snapshot = await owner.prepare_provider(build_self_capture_session_config(japanese))
+    started = await owner.apply_intent(build_self_capture_session_config(japanese), enabled=True)
+
+    assert snapshot.runtime_signature == build_self_stt_runtime_signature(japanese)
+    assert started.runtime_signature == build_self_stt_runtime_signature(japanese)
+    assert [cast(Any, request).config.source_language for request, _start in provider.replace_calls][
+        -1
+    ] == "ja"
+    await owner.close()
+
+
+@pytest.mark.asyncio
+async def test_replace_provider_hot_cloud_language_change_uses_application_path() -> None:
+    korean = _settings(STTProviderName.DEEPGRAM, "ko")
+    japanese = _settings(STTProviderName.DEEPGRAM, "ja")
+    settings_holder = {"settings": korean}
+    provider = _RecordingProvider()
+    session = _build_owner(provider, settings_holder)
+    application = _application_owner(session=session, settings_holder=settings_holder)
+
+    await session.apply_intent(build_self_capture_session_config(korean), enabled=True)
+    settings_holder["settings"] = japanese
+    await application.replace_provider(smooth_local=True)
+
+    assert session.snapshot.runtime_signature == build_self_stt_runtime_signature(japanese)
+    assert provider.handoff_calls
+    assert provider.handoff_calls[-1][0].config.source_language == "ja"
+    await session.close()
+
+
+@pytest.mark.asyncio
+async def test_failed_cloud_language_handoff_does_not_look_applied() -> None:
+    korean = _settings(STTProviderName.DEEPGRAM, "ko")
+    japanese = _settings(STTProviderName.DEEPGRAM, "ja")
+    settings_holder = {"settings": korean}
+    provider = _RecordingProvider()
+    session = _build_owner(provider, settings_holder)
+    application = _application_owner(session=session, settings_holder=settings_holder)
+
+    await session.apply_intent(build_self_capture_session_config(korean), enabled=True)
+    provider.handoff_result = SelfCaptureProviderMutation(SelfCaptureProviderMutationStatus.FAILED)
+    settings_holder["settings"] = japanese
+
+    with pytest.raises(RuntimeError, match="did not apply the requested configuration"):
+        await application.replace_provider(smooth_local=True)
+
+    assert session.snapshot.runtime_signature == build_self_stt_runtime_signature(korean)
+    assert session.snapshot.provider_status is SelfCaptureProviderStatus.READY
+    await session.close()

--- a/tests/core/runtime/test_self_capture_session.py
+++ b/tests/core/runtime/test_self_capture_session.py
@@ -820,6 +820,46 @@ async def test_close_cancels_pending_admission_and_rejects_future_intent() -> No
 
 
 @pytest.mark.asyncio
+async def test_prepare_provider_replaces_when_provider_identity_changes() -> None:
+    owner, _, provider, sources, _, _ = build_owner()
+
+    await owner.prepare_provider(config("one"))
+    snapshot = await owner.prepare_provider(config("two"))
+
+    assert provider.replace_calls == [
+        (("provider-one", False), False),
+        (("provider-two", False), False),
+    ]
+    assert snapshot.runtime_signature == config("two").runtime_signature
+    assert sources == []
+    await owner.close()
+
+
+@pytest.mark.asyncio
+async def test_prepare_provider_reuses_ready_provider_with_same_identity() -> None:
+    owner, _, provider, _, _, _ = build_owner()
+    session_config = config("one")
+
+    await owner.prepare_provider(session_config)
+    await owner.prepare_provider(session_config)
+
+    assert provider.replace_calls == [(("provider-one", False), False)]
+    await owner.close()
+
+
+@pytest.mark.asyncio
+async def test_start_replaces_ready_provider_when_identity_changed() -> None:
+    owner, _, provider, _, _, _ = build_owner()
+
+    await owner.prepare_provider(config("one"))
+    snapshot = await owner.apply_intent(config("two"), enabled=True)
+
+    assert ("provider-two", False) in {request for request, _start in provider.replace_calls}
+    assert snapshot.runtime_signature == config("two").runtime_signature
+    await owner.close()
+
+
+@pytest.mark.asyncio
 async def test_prepare_provider_attaches_without_opening_capture_resources() -> None:
     owner, _, provider, sources, _, _ = build_owner()
     session_config = config(local_cpu=True)


### PR DESCRIPTION
## What does this PR do?

Source-language changes from the dashboard could persist in settings while the live self STT backend kept using the previous language.

This restores the runtime contract without rolling back the v2.4 settings extraction:

- Construction-bound self source language (Deepgram, Qwen ASR, Soniox, custom STT) is part of provider identity, so a hot language change hands off/replaces the real backend.
- Local ASR that can reconfigure in place keeps `session_options` reconfigure.
- `local_cpu_auto` hands off when the new language selects a different resolved model.
- An attached backend is reused only when provider identity matches, so a leftover same-`provider_id` session cannot start with the old language.
- `replace_provider` no longer reports success merely because the previous provider remains READY.

## Related issue

Closes #82

## How was this tested?

Deterministic fakes/spies, no live cloud credentials:

- `tests/app/test_self_stt_source_language_runtime.py`
- `tests/core/runtime/test_self_capture_session.py`
- `tests/app/test_self_capture_application_owner.py`
- related wiring, settings, peer capture, local ASR, and architecture tests

Also ran `uv run ruff check` and `uv run black --check` on the changed files.

## Notes for reviewers

The settings layer still applies STT from the runtime signature with a smooth capture path when VAD is unchanged. Provider names are not special-cased there. Language/model ownership is assigned in `wiring_stt_factory` onto the existing `provider_signature` / `session_options` layers.

Peer STT, Gemma, and custom-vocabulary identity ownership are intentionally unchanged.
