### PR TITLE
harden overlay liveness and unstick next-turn translation

### DIFF
--- a/native/overlay/src/lib.rs
+++ b/native/overlay/src/lib.rs
@@ -40,7 +40,7 @@ pub use renderer::{
 pub use runtime::{
     run_cli, run_with_manifest, NativePresentationOwner, OverlayRuntime, RuntimeFailure,
     StartupError, NATIVE_FRESH_RETRY_CADENCE, NATIVE_FRESH_RETRY_DEADLINE,
-    NATIVE_FRESH_RETRY_MAX_COMPLETED,
+    NATIVE_FRESH_RETRY_MAX_COMPLETED, NATIVE_READINESS_TIMEOUT_RETRY_MAX,
 };
 pub use state::{
     NativeFreshRenderGenerations, OverlayCalibration, OverlayPresentationBlock,

--- a/native/overlay/src/lib.rs
+++ b/native/overlay/src/lib.rs
@@ -17,8 +17,10 @@ pub use manifest::{
     QUIET_TAIL_PROFILE_ENV,
 };
 pub use openvr::{
-    submit_texture, FakeOpenVr, OpenVrError, OpenVrOutputAdapter, OpenVrOverlay, OverlayAnchorMode,
-    OverlayFrameSubmitter, OverlayPlacementPolicy, SpatialReanchorOutcome,
+    submit_texture, FakeOpenVr, OpenVrError, OpenVrEventClass, OpenVrOutputAdapter, OpenVrOverlay,
+    OpenVrRuntimeEvent, OverlayAnchorMode, OverlayFrameSubmitter, OverlayPlacementPolicy,
+    SpatialReanchorOutcome, OPENVR_EVENT_DRIVER_REQUESTED_QUIT, OPENVR_EVENT_OVERLAY_HIDDEN,
+    OPENVR_EVENT_OVERLAY_SHOWN, OPENVR_EVENT_PROCESS_QUIT, OPENVR_EVENT_QUIT,
 };
 pub use presentation::{
     AdapterIdentity, AdapterMatch, CompositorAttribution, PendingPresentationDiagnostics,

--- a/native/overlay/src/openvr.rs
+++ b/native/overlay/src/openvr.rs
@@ -1,4 +1,5 @@
 use std::cell::{Cell, RefCell};
+use std::collections::VecDeque;
 use std::ffi::c_void;
 #[cfg(any(windows, test))]
 use std::ffi::{CStr, CString};
@@ -352,6 +353,61 @@ pub trait OverlayTextureSubmitter {
     fn set_overlay_texture(&self, texture_handle: *mut c_void) -> Result<(), OpenVrError>;
 }
 
+pub const OPENVR_EVENT_OVERLAY_SHOWN: u32 = 500;
+pub const OPENVR_EVENT_OVERLAY_HIDDEN: u32 = 501;
+pub const OPENVR_EVENT_QUIT: u32 = 700;
+pub const OPENVR_EVENT_PROCESS_QUIT: u32 = 701;
+pub const OPENVR_EVENT_DRIVER_REQUESTED_QUIT: u32 = 704;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpenVrEventClass {
+    Fatal,
+    Reconfigure,
+    Ignore,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpenVrRuntimeEvent {
+    OverlayShown,
+    OverlayHidden,
+    Quit,
+    ProcessQuit,
+    DriverRequestedQuit,
+    Ignored(u32),
+}
+
+impl OpenVrRuntimeEvent {
+    pub fn from_event_type(event_type: u32) -> Self {
+        match event_type {
+            OPENVR_EVENT_OVERLAY_SHOWN => Self::OverlayShown,
+            OPENVR_EVENT_OVERLAY_HIDDEN => Self::OverlayHidden,
+            OPENVR_EVENT_QUIT => Self::Quit,
+            OPENVR_EVENT_PROCESS_QUIT => Self::ProcessQuit,
+            OPENVR_EVENT_DRIVER_REQUESTED_QUIT => Self::DriverRequestedQuit,
+            other => Self::Ignored(other),
+        }
+    }
+
+    pub fn classify(self) -> OpenVrEventClass {
+        match self {
+            Self::Quit | Self::ProcessQuit | Self::DriverRequestedQuit => OpenVrEventClass::Fatal,
+            Self::OverlayShown | Self::OverlayHidden => OpenVrEventClass::Reconfigure,
+            Self::Ignored(_) => OpenVrEventClass::Ignore,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::OverlayShown => "overlay_shown",
+            Self::OverlayHidden => "overlay_hidden",
+            Self::Quit => "quit",
+            Self::ProcessQuit => "process_quit",
+            Self::DriverRequestedQuit => "driver_requested_quit",
+            Self::Ignored(_) => "ignored",
+        }
+    }
+}
+
 pub trait OverlayFrameSubmitter {
     fn submit_frame(&mut self, frame: &RenderedFrame) -> Result<(), OpenVrError>;
 
@@ -369,6 +425,15 @@ pub trait OverlayFrameSubmitter {
 
     fn set_overlay_visible(&mut self, _visible: bool) -> Result<(), OpenVrError> {
         Ok(())
+    }
+
+    fn observed_overlay_visible(&self) -> Option<bool> {
+        None
+    }
+
+    fn poll_runtime_events(&mut self, max_events: usize) -> Vec<OpenVrRuntimeEvent> {
+        let _ = max_events;
+        Vec::new()
     }
 
     fn take_visibility_api_call_log(&mut self) -> Option<String> {
@@ -434,6 +499,8 @@ pub struct FakeOpenVr {
     call_sequence: RefCell<Vec<&'static str>>,
     spatial_reanchor_count: Cell<usize>,
     visible: Cell<bool>,
+    observed_visible: Cell<Option<bool>>,
+    pending_events: RefCell<VecDeque<OpenVrRuntimeEvent>>,
     last_visibility_api_call_log: RefCell<Option<String>>,
 }
 
@@ -448,6 +515,14 @@ impl FakeOpenVr {
 
     pub fn spatial_reanchor_count(&self) -> usize {
         self.spatial_reanchor_count.get()
+    }
+
+    pub fn set_observed_overlay_visible(&self, visible: Option<bool>) {
+        self.observed_visible.set(visible);
+    }
+
+    pub fn push_runtime_event(&self, event: OpenVrRuntimeEvent) {
+        self.pending_events.borrow_mut().push_back(event);
     }
 }
 
@@ -495,6 +570,14 @@ impl OverlayFrameSubmitter for OpenVrOverlay {
 
     fn set_overlay_visible(&mut self, visible: bool) -> Result<(), OpenVrError> {
         self.backend.set_overlay_visible(visible)
+    }
+
+    fn observed_overlay_visible(&self) -> Option<bool> {
+        self.backend.observed_overlay_visible()
+    }
+
+    fn poll_runtime_events(&mut self, max_events: usize) -> Vec<OpenVrRuntimeEvent> {
+        self.backend.poll_runtime_events(max_events)
     }
 
     fn take_visibility_api_call_log(&mut self) -> Option<String> {
@@ -615,6 +698,24 @@ impl OpenVrBackend {
             Self::Windows(openvr) => openvr.set_overlay_visible(visible),
             #[cfg(not(windows))]
             Self::Test(openvr) => openvr.set_overlay_visible(visible),
+        }
+    }
+
+    fn observed_overlay_visible(&self) -> Option<bool> {
+        match self {
+            #[cfg(windows)]
+            Self::Windows(openvr) => openvr.observed_overlay_visible(),
+            #[cfg(not(windows))]
+            Self::Test(openvr) => openvr.observed_overlay_visible(),
+        }
+    }
+
+    fn poll_runtime_events(&mut self, max_events: usize) -> Vec<OpenVrRuntimeEvent> {
+        match self {
+            #[cfg(windows)]
+            Self::Windows(openvr) => openvr.poll_runtime_events(max_events),
+            #[cfg(not(windows))]
+            Self::Test(openvr) => openvr.poll_runtime_events(max_events),
         }
     }
 
@@ -755,9 +856,55 @@ impl WindowsOpenVrOverlay {
         reanchor_spatial_locked_with_api(&policy, self)
     }
 
+    fn observed_overlay_visible(&self) -> Option<bool> {
+        let is_visible = self.overlay_api().IsOverlayVisible?;
+        Some(unsafe { is_visible(self.overlay_handle) })
+    }
+
+    fn poll_runtime_events(&mut self, max_events: usize) -> Vec<OpenVrRuntimeEvent> {
+        let mut events = Vec::new();
+        if max_events == 0 {
+            return events;
+        }
+        if let Some(poll) = self.overlay_api().PollNextOverlayEvent {
+            while events.len() < max_events {
+                let mut event = unsafe { std::mem::zeroed::<openvr_sys::VREvent_t>() };
+                let got = unsafe {
+                    poll(
+                        self.overlay_handle,
+                        &mut event,
+                        std::mem::size_of::<openvr_sys::VREvent_t>() as u32,
+                    )
+                };
+                if !got {
+                    break;
+                }
+                events.push(OpenVrRuntimeEvent::from_event_type(event.eventType));
+            }
+        }
+        if let Some(poll) = self.system_api().PollNextEvent {
+            while events.len() < max_events {
+                let mut event = unsafe { std::mem::zeroed::<openvr_sys::VREvent_t>() };
+                let got = unsafe {
+                    poll(
+                        &mut event,
+                        std::mem::size_of::<openvr_sys::VREvent_t>() as u32,
+                    )
+                };
+                if !got {
+                    break;
+                }
+                events.push(OpenVrRuntimeEvent::from_event_type(event.eventType));
+            }
+        }
+        events
+    }
+
     fn set_overlay_visible(&mut self, visible: bool) -> Result<(), OpenVrError> {
         let cached_visible_before = self.visible;
-        if self.visible == visible {
+        let actual_visible = self.observed_overlay_visible();
+        if actual_visible.unwrap_or(self.visible) == visible {
+            self.visible = actual_visible.unwrap_or(visible);
             self.last_visibility_api_call_log = Some(format_openvr_visibility_api_call_log(
                 visible,
                 cached_visible_before,
@@ -777,6 +924,9 @@ impl WindowsOpenVrOverlay {
             self.hide_overlay()?;
         }
         self.visible = visible;
+        if let Some(actual_visible) = self.observed_overlay_visible() {
+            self.visible = actual_visible;
+        }
         self.last_visibility_api_call_log = Some(format_openvr_visibility_api_call_log(
             visible,
             cached_visible_before,
@@ -1025,15 +1175,21 @@ impl OverlayFrameSubmitter for FakeOpenVr {
 
     fn set_overlay_visible(&mut self, visible: bool) -> Result<(), OpenVrError> {
         let cached_visible_before = self.visible.get();
-        let api = if cached_visible_before == visible {
+        let actual_visible = self
+            .observed_overlay_visible()
+            .unwrap_or(cached_visible_before);
+        let api = if actual_visible == visible {
             "SkipCachedMatch"
         } else if visible {
             "ShowOverlay"
         } else {
             "HideOverlay"
         };
-        if cached_visible_before != visible {
+        if actual_visible != visible {
             self.last_call.replace(Some(api.to_string()));
+            self.visible.set(visible);
+            self.observed_visible.set(Some(visible));
+        } else {
             self.visible.set(visible);
         }
         self.last_visibility_api_call_log
@@ -1044,6 +1200,26 @@ impl OverlayFrameSubmitter for FakeOpenVr {
                 self.visible.get(),
             )));
         Ok(())
+    }
+
+    fn observed_overlay_visible(&self) -> Option<bool> {
+        Some(
+            self.observed_visible
+                .get()
+                .unwrap_or_else(|| self.visible.get()),
+        )
+    }
+
+    fn poll_runtime_events(&mut self, max_events: usize) -> Vec<OpenVrRuntimeEvent> {
+        let mut events = Vec::new();
+        let mut pending = self.pending_events.borrow_mut();
+        while events.len() < max_events {
+            let Some(event) = pending.pop_front() else {
+                break;
+            };
+            events.push(event);
+        }
+        events
     }
 
     fn take_visibility_api_call_log(&mut self) -> Option<String> {
@@ -1272,9 +1448,10 @@ mod tests {
         fn_table_interface_version, reanchor_spatial_locked_with_api, requested_adapter_identity,
         run_startup_preflight, spatial_locked_transform, split_output_device_luid,
         validate_resolved_adapter, FakeOpenVr, OpenVrBackgroundInitError, OpenVrError,
-        OpenVrPreflightApi, OpenVrStartupPreflightError, OverlayAnchorMode, OverlayFrameSubmitter,
-        OverlayPlacementApi, OverlayPlacementPolicy, SpatialHmdPose, SpatialReanchorApi,
-        SpatialReanchorOutcome, SpatialTrackingOrigin, DEFAULT_OVERLAY_WIDTH_METERS,
+        OpenVrEventClass, OpenVrPreflightApi, OpenVrRuntimeEvent, OpenVrStartupPreflightError,
+        OverlayAnchorMode, OverlayFrameSubmitter, OverlayPlacementApi, OverlayPlacementPolicy,
+        SpatialHmdPose, SpatialReanchorApi, SpatialReanchorOutcome, SpatialTrackingOrigin,
+        DEFAULT_OVERLAY_WIDTH_METERS, OPENVR_EVENT_OVERLAY_HIDDEN, OPENVR_EVENT_QUIT,
     };
     use crate::state::OverlayCalibration;
 
@@ -1781,5 +1958,57 @@ mod tests {
         assert!(skip_log.contains("cached_visible_before=true"));
         assert!(skip_log.contains("api=SkipCachedMatch"));
         assert!(skip_log.contains("cached_visible_after=true"));
+    }
+
+    #[test]
+    fn fake_openvr_reasserts_show_when_cached_visible_but_actual_hidden() {
+        let mut openvr = FakeOpenVr::default();
+        openvr.set_overlay_visible(true).expect("show overlay");
+        openvr.set_observed_overlay_visible(Some(false));
+
+        openvr
+            .set_overlay_visible(true)
+            .expect("reassert show overlay");
+        let log = openvr
+            .take_visibility_api_call_log()
+            .expect("reassert visibility log");
+        assert!(log.contains("desired_visible=true"));
+        assert!(log.contains("cached_visible_before=true"));
+        assert!(log.contains("api=ShowOverlay"));
+        assert_eq!(openvr.observed_overlay_visible(), Some(true));
+    }
+
+    #[test]
+    fn openvr_runtime_events_classify_fatal_reconfigure_and_ignore() {
+        assert_eq!(
+            OpenVrRuntimeEvent::from_event_type(OPENVR_EVENT_QUIT).classify(),
+            OpenVrEventClass::Fatal
+        );
+        assert_eq!(
+            OpenVrRuntimeEvent::from_event_type(OPENVR_EVENT_OVERLAY_HIDDEN).classify(),
+            OpenVrEventClass::Reconfigure
+        );
+        assert_eq!(
+            OpenVrRuntimeEvent::from_event_type(1).classify(),
+            OpenVrEventClass::Ignore
+        );
+    }
+
+    #[test]
+    fn fake_openvr_poll_runtime_events_are_bounded() {
+        let mut openvr = FakeOpenVr::default();
+        for _ in 0..8 {
+            openvr.push_runtime_event(OpenVrRuntimeEvent::Ignored(1));
+        }
+        openvr.push_runtime_event(OpenVrRuntimeEvent::Quit);
+
+        let first = openvr.poll_runtime_events(3);
+        assert_eq!(first.len(), 3);
+        assert!(first
+            .iter()
+            .all(|event| *event == OpenVrRuntimeEvent::Ignored(1)));
+        let rest = openvr.poll_runtime_events(16);
+        assert_eq!(rest.len(), 6);
+        assert_eq!(rest[5], OpenVrRuntimeEvent::Quit);
     }
 }

--- a/native/overlay/src/runtime.rs
+++ b/native/overlay/src/runtime.rs
@@ -1511,6 +1511,7 @@ pub const NATIVE_FRESH_RETRY_CADENCE: Duration = Duration::from_millis(100);
 pub const NATIVE_FRESH_RETRY_DEADLINE: Duration = Duration::from_millis(500);
 pub const NATIVE_FRESH_RETRY_MAX_COMPLETED: u32 = 5;
 pub const NATIVE_STREAM_RETRY_MAX_COMPLETED: u32 = 4;
+pub const NATIVE_READINESS_TIMEOUT_RETRY_MAX: u32 = NATIVE_FRESH_RETRY_MAX_COMPLETED;
 const NATIVE_FRESH_AUDIT_CAPACITY: usize = 128;
 
 #[derive(Debug, Clone, Copy)]
@@ -1635,6 +1636,9 @@ pub struct NativePresentationOwner<S: OverlayFrameSubmitter> {
     fresh_retry_audit: VecDeque<NativeFreshAuditFact>,
     fresh_retry_audit_dropped: u64,
     successful_attempt_audit: VecDeque<PresentationCorrelation>,
+    consecutive_readiness_timeouts: u32,
+    max_consecutive_readiness_timeouts: u32,
+    readiness_retry_due: Option<Instant>,
 }
 
 impl<S: OverlayFrameSubmitter> NativePresentationOwner<S> {
@@ -1664,6 +1668,9 @@ impl<S: OverlayFrameSubmitter> NativePresentationOwner<S> {
             fresh_retry_audit: VecDeque::with_capacity(NATIVE_FRESH_AUDIT_CAPACITY),
             fresh_retry_audit_dropped: 0,
             successful_attempt_audit: VecDeque::with_capacity(NATIVE_FRESH_AUDIT_CAPACITY),
+            consecutive_readiness_timeouts: 0,
+            max_consecutive_readiness_timeouts: NATIVE_READINESS_TIMEOUT_RETRY_MAX,
+            readiness_retry_due: None,
         }
     }
 
@@ -1697,6 +1704,11 @@ impl<S: OverlayFrameSubmitter> NativePresentationOwner<S> {
             max_completed,
         };
         owner
+    }
+
+    #[doc(hidden)]
+    pub fn set_max_consecutive_readiness_timeouts_for_test(&mut self, max_timeouts: u32) {
+        self.max_consecutive_readiness_timeouts = max_timeouts;
     }
 
     pub fn runtime(&self) -> &PresentationRuntime {
@@ -1746,6 +1758,8 @@ impl<S: OverlayFrameSubmitter> NativePresentationOwner<S> {
     }
 
     fn capture_successful_attempt(&mut self) {
+        self.consecutive_readiness_timeouts = 0;
+        self.readiness_retry_due = None;
         let Some(correlation) = self.runtime.last_presentation_correlation else {
             return;
         };
@@ -2046,6 +2060,61 @@ impl<S: OverlayFrameSubmitter> NativePresentationOwner<S> {
             .min()
     }
 
+    fn next_retry_wake(&self) -> Option<Instant> {
+        [self.next_fresh_due(), self.readiness_retry_due]
+            .into_iter()
+            .flatten()
+            .min()
+    }
+
+    async fn note_readiness_timeout(
+        &mut self,
+        logger: &OverlayLogger,
+    ) -> Result<(), RuntimeFailure> {
+        self.consecutive_readiness_timeouts = self.consecutive_readiness_timeouts.saturating_add(1);
+        self.runtime.request_native_presentation_retry();
+        let due = Instant::now() + self.retry_policy.cadence;
+        let mut deferred_schedule = false;
+        if let Some(schedule) = self.self_schedule.as_mut() {
+            schedule.next_due = due;
+            deferred_schedule = true;
+        }
+        if let Some(schedule) = self.peer_schedule.as_mut() {
+            schedule.next_due = due;
+            deferred_schedule = true;
+        }
+        if !deferred_schedule {
+            self.readiness_retry_due = Some(due);
+        }
+        log_runtime_info(
+            logger,
+            format!(
+                "readiness_timeout_retry consecutive={} max={} physical_hmd_visibility=not_observable",
+                self.consecutive_readiness_timeouts, self.max_consecutive_readiness_timeouts,
+            ),
+        )
+        .await?;
+        if self.consecutive_readiness_timeouts >= self.max_consecutive_readiness_timeouts {
+            return Err(RuntimeFailure::ReadinessTimedOut);
+        }
+        Ok(())
+    }
+
+    async fn complete_frame_cycle(
+        &mut self,
+        result: Result<FrameCycleOutcome, RuntimeFailure>,
+        logger: &OverlayLogger,
+    ) -> Result<Option<FrameCycleOutcome>, RuntimeFailure> {
+        match result {
+            Ok(outcome) => Ok(Some(outcome)),
+            Err(RuntimeFailure::ReadinessTimedOut) => {
+                self.note_readiness_timeout(logger).await?;
+                Ok(None)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
     fn due_fresh_channels(&self, now: Instant) -> Vec<FreshRetryChannel> {
         [self.self_schedule.clone(), self.peer_schedule.clone()]
             .into_iter()
@@ -2134,6 +2203,7 @@ impl<S: OverlayFrameSubmitter> NativePresentationOwner<S> {
         if due.is_empty() {
             return Ok(FrameCycleOutcome::NoWork);
         }
+        self.readiness_retry_due = None;
         for schedule in &due {
             self.runtime
                 .request_fresh_presentation_retry(schedule.channel, schedule.trigger_generation);
@@ -2149,6 +2219,10 @@ impl<S: OverlayFrameSubmitter> NativePresentationOwner<S> {
         };
         let outcome = match attempt {
             Ok(outcome) => outcome,
+            Err(RuntimeFailure::ReadinessTimedOut) => {
+                self.note_readiness_timeout(logger).await?;
+                return Ok(FrameCycleOutcome::NoWork);
+            }
             Err(primary_failure) => {
                 for schedule in due {
                     let active = match schedule.channel {
@@ -2270,15 +2344,24 @@ impl<S: OverlayFrameSubmitter> NativePresentationOwner<S> {
                 .submit_initial_frame_message_aware(renderer, openvr, bridge, logger)
                 .await
         };
+        let initial_timed_out = matches!(&initial_result, Err(RuntimeFailure::ReadinessTimedOut));
         if let Err(error) = initial_result {
-            self.teardown();
-            return Err(error);
+            if !initial_timed_out {
+                self.teardown();
+                return Err(error);
+            }
+            if let Err(error) = self.note_readiness_timeout(logger).await {
+                self.teardown();
+                return Err(error);
+            }
         }
         if self.runtime.is_stopped() {
             self.teardown();
             return Ok(());
         }
-        self.capture_successful_attempt();
+        if !initial_timed_out {
+            self.capture_successful_attempt();
+        }
         let reconcile_result = self.reconcile_fresh_schedules(logger).await;
         self.finish_initial_reconcile(reconcile_result)?;
 
@@ -2300,11 +2383,29 @@ impl<S: OverlayFrameSubmitter> NativePresentationOwner<S> {
             } else {
                 tokio::select! {
                     biased;
-                    _ = sleep_until(self.next_fresh_due().unwrap_or_else(Instant::now)), if self.next_fresh_due().is_some() => {
-                        let channels = self.due_fresh_channels(Instant::now());
+                    _ = sleep_until(self.next_retry_wake().unwrap_or_else(Instant::now)), if self.next_retry_wake().is_some() => {
+                        let now = Instant::now();
+                        let channels = self.due_fresh_channels(now);
                         if !channels.is_empty() {
                             let outcome = self.run_due_fresh_attempt(channels, bridge, logger).await?;
                             pending_message = outcome.pending_message();
+                        } else if self.readiness_retry_due.is_some_and(|due| due <= now) {
+                            self.readiness_retry_due = None;
+                            let result = {
+                                let renderer = self.renderer.as_ref().expect("active renderer");
+                                let openvr = self.openvr.as_mut().expect("active OpenVR session");
+                                self.runtime
+                                    .submit_frame_if_needed_with_timing(
+                                        renderer, openvr, bridge, logger, None, None, true,
+                                    )
+                                    .await
+                            };
+                            if let Some(outcome) = self.complete_frame_cycle(result, logger).await? {
+                                if matches!(&outcome, FrameCycleOutcome::Submitted) {
+                                    self.capture_successful_attempt();
+                                }
+                                pending_message = outcome.pending_message();
+                            }
                         }
                         None
                     }
@@ -2322,27 +2423,35 @@ impl<S: OverlayFrameSubmitter> NativePresentationOwner<S> {
                         self.runtime.request_native_presentation_retry();
                         let renderer = self.renderer.as_ref().expect("active renderer");
                         let openvr = self.openvr.as_mut().expect("active OpenVR session");
-                        let outcome = self.runtime
+                        let result = self.runtime
                             .submit_frame_if_needed_with_timing(
                                 renderer, openvr, bridge, logger, None, None, true,
                             )
-                            .await?;
-                        if matches!(&outcome, FrameCycleOutcome::Submitted) {
-                            self.capture_successful_attempt();
-                            self.satisfy_schedules_from_last_submission(
-                                logger,
-                                &captured_schedules,
-                                PresentationCauseKind::ActiveRetryIntent,
-                            ).await?;
-                        } else {
-                            for schedule in captured_schedules {
-                                self.runtime.pending_presentation_causes.remove(Self::intent_cause(
-                                    &schedule,
-                                    PresentationCauseKind::ActiveRetryIntent,
-                                ));
+                            .await;
+                        match self.complete_frame_cycle(result, logger).await? {
+                            Some(outcome) => {
+                                if matches!(&outcome, FrameCycleOutcome::Submitted) {
+                                    self.capture_successful_attempt();
+                                    self.satisfy_schedules_from_last_submission(
+                                        logger,
+                                        &captured_schedules,
+                                        PresentationCauseKind::ActiveRetryIntent,
+                                    ).await?;
+                                } else {
+                                    for schedule in captured_schedules {
+                                        self.runtime.pending_presentation_causes.remove(Self::intent_cause(
+                                            &schedule,
+                                            PresentationCauseKind::ActiveRetryIntent,
+                                        ));
+                                    }
+                                }
+                                pending_message = outcome.pending_message();
+                            }
+                            None => {
+                                self.remove_temporary_intent_causes(&captured_schedules);
+                                pending_message = None;
                             }
                         }
-                        pending_message = outcome.pending_message();
                         None
                     }
                     _ = sleep_until(hide_deadline.unwrap_or_else(Instant::now)), if hide_deadline.is_some() => {
@@ -2372,6 +2481,11 @@ impl<S: OverlayFrameSubmitter> NativePresentationOwner<S> {
                     .await;
                 let (continue_running, preempted_message) = match handled {
                     Ok(handled) => handled,
+                    Err(RuntimeFailure::ReadinessTimedOut) => {
+                        self.note_readiness_timeout(logger).await?;
+                        self.remove_temporary_intent_causes(&captured_schedules);
+                        continue;
+                    }
                     Err(error) => {
                         self.remove_temporary_intent_causes(&captured_schedules);
                         return Err(error);

--- a/native/overlay/src/runtime.rs
+++ b/native/overlay/src/runtime.rs
@@ -19,7 +19,8 @@ use crate::manifest::{
 use crate::openvr::OpenVrError;
 use crate::openvr::{
     format_openvr_visibility_api_call_log, perform_startup_preflight, FrameTimingSample,
-    OpenVrOverlay, OpenVrStartupPreflightError, OverlayFrameSubmitter, SpatialReanchorOutcome,
+    OpenVrEventClass, OpenVrOverlay, OpenVrRuntimeEvent, OpenVrStartupPreflightError,
+    OverlayFrameSubmitter, SpatialReanchorOutcome,
 };
 use crate::presentation::{
     PresentationBackend, PresentationCause, PresentationCauseChannel, PresentationCauseKind,
@@ -42,6 +43,8 @@ const TWO_ROW_WINDOW_STABILITY_THRESHOLD_MS: u64 = 500;
 const PRESENTATION_DIAGNOSTIC_WRITE_TIMEOUT: Duration = Duration::from_millis(25);
 const GPU_READINESS_OWNER_TIMEOUT: Duration = Duration::from_millis(50);
 const MAX_IGNORED_MESSAGES_BEFORE_READINESS_POLL: usize = 8;
+const MAX_OPENVR_EVENTS_PER_TURN: usize = 8;
+const OPENVR_EVENT_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum StartupError {
@@ -875,6 +878,11 @@ impl PresentationRuntime {
             &self.pending_peer_first_render_ids,
         );
         cpu_prepare_us = cpu_prepare_us.saturating_add(duration_us(prepare_resumed.elapsed()));
+        if has_drawable_text {
+            if let Some(actual_visible) = openvr.observed_overlay_visible() {
+                self.overlay_visible = actual_visible;
+            }
+        }
         let overlay_visible_before = self.overlay_visible;
         let should_show_after_submit = has_drawable_text && !self.overlay_visible;
         let hide_deadline_was_active = self.hide_deadline.is_some();
@@ -1360,6 +1368,14 @@ impl PresentationRuntime {
         self.caption_blocks()
             .iter()
             .any(CaptionBlock::has_drawable_text)
+    }
+
+    fn desires_overlay_visible(&self) -> bool {
+        self.first_texture_submitted && (self.has_drawable_text() || self.hide_deadline.is_some())
+    }
+
+    fn note_observed_runtime_visible(&mut self, visible: bool) {
+        self.overlay_visible = visible;
     }
 
     async fn emit_pending_spatial_diagnostics(&mut self, logger: &OverlayLogger) {
@@ -2370,6 +2386,68 @@ impl<S: OverlayFrameSubmitter> NativePresentationOwner<S> {
         result
     }
 
+    async fn pump_openvr_events(&mut self, logger: &OverlayLogger) -> Result<(), RuntimeFailure> {
+        let events = {
+            let openvr = self.openvr.as_mut().expect("active OpenVR session");
+            openvr.poll_runtime_events(MAX_OPENVR_EVENTS_PER_TURN)
+        };
+        let mut saw_overlay_hidden = false;
+        for event in events {
+            match event.classify() {
+                OpenVrEventClass::Ignore => {}
+                OpenVrEventClass::Fatal => {
+                    return Err(RuntimeFailure::OpenVr(format!("event={}", event.as_str())));
+                }
+                OpenVrEventClass::Reconfigure => {
+                    log_runtime_info(
+                        logger,
+                        format!(
+                            "openvr_event_classified type={} class=reconfigure physical_hmd_visibility=not_observable",
+                            event.as_str()
+                        ),
+                    )
+                    .await?;
+                    match event {
+                        OpenVrRuntimeEvent::OverlayShown => {
+                            self.runtime.note_observed_runtime_visible(true);
+                        }
+                        OpenVrRuntimeEvent::OverlayHidden => {
+                            saw_overlay_hidden = true;
+                            self.runtime.note_observed_runtime_visible(false);
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        let observed = {
+            let openvr = self.openvr.as_mut().expect("active OpenVR session");
+            openvr.observed_overlay_visible()
+        };
+        if let Some(visible) = observed {
+            self.runtime.note_observed_runtime_visible(visible);
+        }
+        let desired_visible = self.runtime.desires_overlay_visible();
+        let needs_reassert = match observed {
+            Some(visible) => visible != desired_visible,
+            None => saw_overlay_hidden && desired_visible,
+        };
+        if needs_reassert {
+            let message = {
+                let openvr = self.openvr.as_mut().expect("active OpenVR session");
+                openvr
+                    .set_overlay_visible(desired_visible)
+                    .map_err(|error| RuntimeFailure::OpenVr(error.to_string()))?;
+                openvr.take_visibility_api_call_log()
+            };
+            self.runtime.note_observed_runtime_visible(desired_visible);
+            if let Some(message) = message {
+                log_runtime_info(logger, message).await?;
+            }
+        }
+        Ok(())
+    }
+
     async fn run_owned_event_loop(
         &mut self,
         bridge: &mut BridgeClient,
@@ -2377,6 +2455,7 @@ impl<S: OverlayFrameSubmitter> NativePresentationOwner<S> {
     ) -> Result<(), RuntimeFailure> {
         let mut pending_message = None;
         loop {
+            self.pump_openvr_events(logger).await?;
             let hide_deadline = self.runtime.hide_deadline;
             let message = if let Some(message) = pending_message.take() {
                 Some(message)
@@ -2459,7 +2538,8 @@ impl<S: OverlayFrameSubmitter> NativePresentationOwner<S> {
                         self.runtime.handle_hide_deadline(openvr, logger).await?;
                         None
                     }
-                    message = bridge.next_message() => Some(message)
+                    message = bridge.next_message() => Some(message),
+                    _ = sleep_until(Instant::now() + OPENVR_EVENT_POLL_INTERVAL) => None,
                 }
             };
             if let Some(message) = message {

--- a/native/overlay/tests/runtime.rs
+++ b/native/overlay/tests/runtime.rs
@@ -16,13 +16,13 @@ use puripuly_heart_overlay::runtime::SnapshotApplyOutcome;
 use puripuly_heart_overlay::{
     load_manifest, resolve_quiet_tail_profile, run_with_manifest, submit_texture,
     validate_manifest, AdapterIdentity, BridgeClient, CaptionBlock, CaptionChannel,
-    CaptionRenderer, FakeOpenVr, NativePresentationOwner, OpenVrError, OverlayBridgeEvent,
-    OverlayFrameSubmitter, OverlayLoggingMode, OverlayManifest, OverlayPresentationBlock,
-    OverlayPresentationBlockVariant, OverlayPresentationCalibration, OverlayPresentationSnapshot,
-    OverlayRuntime, PresentationBackend, PresentationCause, PresentationCauseChannel,
-    PresentationCauseKind, PresentationOutcome, PresentationStage, PresentationStrategy,
-    QuietTailProfile, ReadinessOutcome, RenderedFrame, RuntimeFailure, SpatialReanchorOutcome,
-    StartupError, EXPECTED_CONTRACT_VERSION, NATIVE_FRESH_RETRY_CADENCE,
+    CaptionRenderer, FakeOpenVr, NativePresentationOwner, OpenVrError, OpenVrRuntimeEvent,
+    OverlayBridgeEvent, OverlayFrameSubmitter, OverlayLoggingMode, OverlayManifest,
+    OverlayPresentationBlock, OverlayPresentationBlockVariant, OverlayPresentationCalibration,
+    OverlayPresentationSnapshot, OverlayRuntime, PresentationBackend, PresentationCause,
+    PresentationCauseChannel, PresentationCauseKind, PresentationOutcome, PresentationStage,
+    PresentationStrategy, QuietTailProfile, ReadinessOutcome, RenderedFrame, RuntimeFailure,
+    SpatialReanchorOutcome, StartupError, EXPECTED_CONTRACT_VERSION, NATIVE_FRESH_RETRY_CADENCE,
     NATIVE_FRESH_RETRY_DEADLINE, NATIVE_FRESH_RETRY_MAX_COMPLETED,
     NATIVE_READINESS_TIMEOUT_RETRY_MAX,
 };
@@ -511,6 +511,153 @@ impl OverlayFrameSubmitter for OwnedSubmitterProbe {
             .unwrap()
             .push(if visible { "show" } else { "hide" });
         Ok(())
+    }
+}
+
+#[derive(Default)]
+struct DivergingVisibilitySubmitter {
+    operations: Vec<&'static str>,
+    observed: Option<bool>,
+}
+
+impl OverlayFrameSubmitter for DivergingVisibilitySubmitter {
+    fn submit_frame(&mut self, frame: &RenderedFrame) -> Result<(), OpenVrError> {
+        self.operations
+            .push(if frame.layout().visible_blocks.is_empty() {
+                "submit:empty"
+            } else {
+                "submit:text"
+            });
+        Ok(())
+    }
+
+    fn set_overlay_visible(&mut self, visible: bool) -> Result<(), OpenVrError> {
+        self.operations.push(if visible { "show" } else { "hide" });
+        self.observed = Some(visible);
+        Ok(())
+    }
+
+    fn observed_overlay_visible(&self) -> Option<bool> {
+        self.observed
+    }
+}
+
+#[derive(Default)]
+struct EventFloodState {
+    operations: Mutex<Vec<&'static str>>,
+    poll_calls: AtomicUsize,
+    max_events_in_one_poll: AtomicUsize,
+}
+
+struct EventFloodSubmitter {
+    state: Arc<EventFloodState>,
+}
+
+impl OverlayFrameSubmitter for EventFloodSubmitter {
+    fn submit_frame(&mut self, frame: &RenderedFrame) -> Result<(), OpenVrError> {
+        self.state
+            .operations
+            .lock()
+            .unwrap()
+            .push(if frame.layout().visible_blocks.is_empty() {
+                "submit:empty"
+            } else {
+                "submit:text"
+            });
+        Ok(())
+    }
+
+    fn set_overlay_visible(&mut self, visible: bool) -> Result<(), OpenVrError> {
+        self.state
+            .operations
+            .lock()
+            .unwrap()
+            .push(if visible { "show" } else { "hide" });
+        Ok(())
+    }
+
+    fn poll_runtime_events(&mut self, max_events: usize) -> Vec<OpenVrRuntimeEvent> {
+        self.state.poll_calls.fetch_add(1, Ordering::SeqCst);
+        self.state
+            .max_events_in_one_poll
+            .fetch_max(max_events, Ordering::SeqCst);
+        vec![OpenVrRuntimeEvent::Ignored(1); max_events]
+    }
+}
+
+struct OverlayHiddenSubmitter {
+    state: Arc<OwnedSubmitterState>,
+    shown: bool,
+    hidden_emitted: bool,
+}
+
+impl OverlayFrameSubmitter for OverlayHiddenSubmitter {
+    fn submit_frame(&mut self, frame: &RenderedFrame) -> Result<(), OpenVrError> {
+        self.state
+            .operations
+            .lock()
+            .unwrap()
+            .push(if frame.layout().visible_blocks.is_empty() {
+                "submit:empty"
+            } else {
+                "submit:text"
+            });
+        Ok(())
+    }
+
+    fn set_overlay_visible(&mut self, visible: bool) -> Result<(), OpenVrError> {
+        self.state
+            .operations
+            .lock()
+            .unwrap()
+            .push(if visible { "show" } else { "hide" });
+        if visible {
+            self.shown = true;
+        }
+        Ok(())
+    }
+
+    fn poll_runtime_events(&mut self, _max_events: usize) -> Vec<OpenVrRuntimeEvent> {
+        if self.shown && !self.hidden_emitted {
+            self.hidden_emitted = true;
+            vec![OpenVrRuntimeEvent::OverlayHidden]
+        } else {
+            Vec::new()
+        }
+    }
+}
+
+struct ObservedVisibilitySubmitter {
+    state: Arc<OwnedSubmitterState>,
+    observed: Option<bool>,
+}
+
+impl OverlayFrameSubmitter for ObservedVisibilitySubmitter {
+    fn submit_frame(&mut self, frame: &RenderedFrame) -> Result<(), OpenVrError> {
+        self.state
+            .operations
+            .lock()
+            .unwrap()
+            .push(if frame.layout().visible_blocks.is_empty() {
+                "submit:empty"
+            } else {
+                "submit:text"
+            });
+        Ok(())
+    }
+
+    fn set_overlay_visible(&mut self, visible: bool) -> Result<(), OpenVrError> {
+        self.state
+            .operations
+            .lock()
+            .unwrap()
+            .push(if visible { "show" } else { "hide" });
+        self.observed = Some(visible);
+        Ok(())
+    }
+
+    fn observed_overlay_visible(&self) -> Option<bool> {
+        self.observed
     }
 }
 
@@ -2314,6 +2461,44 @@ async fn runtime_records_failed_hide_visibility_without_false_observation() {
     assert_eq!(visibility.desired_visible, Some(false));
     assert_eq!(visibility.observed_runtime_visible, Some(true));
     assert_eq!(submitter.operations.last(), Some(&"hide"));
+    drop(bridge);
+    let _ = server.await.unwrap();
+}
+
+#[tokio::test]
+async fn runtime_reasserts_show_when_cached_visible_but_actual_hidden() {
+    let renderer = CaptionRenderer::new_for_test().unwrap();
+    let logger = test_logger("cached-visible-actual-hidden").await;
+    let (mut bridge, server) = connect_test_bridge().await;
+    let mut runtime = OverlayRuntime::new(OverlayPresentationSnapshot {
+        revision: 1,
+        calibration: OverlayPresentationCalibration::default(),
+        native_fresh_render_generations: None,
+        blocks: vec![block("self:visible", "self", "visible", "", true)],
+    });
+    let mut submitter = DivergingVisibilitySubmitter::default();
+    runtime
+        .submit_frame_if_needed(&renderer, &mut submitter, &mut bridge, &logger)
+        .await
+        .unwrap();
+    assert_eq!(submitter.operations, vec!["submit:text", "show"]);
+
+    submitter.observed = Some(false);
+    runtime.apply_snapshot(OverlayPresentationSnapshot {
+        revision: 2,
+        calibration: OverlayPresentationCalibration::default(),
+        native_fresh_render_generations: None,
+        blocks: vec![block("self:later", "self", "later", "", true)],
+    });
+    runtime
+        .submit_frame_if_needed(&renderer, &mut submitter, &mut bridge, &logger)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        submitter.operations,
+        vec!["submit:text", "show", "submit:text", "show"]
+    );
     drop(bridge);
     let _ = server.await.unwrap();
 }
@@ -4439,6 +4624,282 @@ async fn production_owner_single_readiness_timeout_retries_without_submit_or_exi
             .count(),
         1
     );
+    assert!(owner.resources_released());
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn production_owner_openvr_event_flood_does_not_starve_snapshot_submit() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let state = Arc::new(EventFloodState::default());
+    let server_state = state.clone();
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut ws = accept_async(stream).await.unwrap();
+        let _auth = ws.next().await.unwrap().unwrap();
+        ws.send(Message::Text(
+            json!({"type":"snapshot","payload":{
+                "revision":1,
+                "blocks":[block("self:flood-1","self","first","",true)]
+            }})
+            .to_string()
+            .into(),
+        ))
+        .await
+        .unwrap();
+        loop {
+            let message = ws.next().await.unwrap().unwrap();
+            if message.to_text().unwrap().contains("overlay_ready") {
+                break;
+            }
+        }
+        ws.send(Message::Text(
+            json!({"type":"snapshot","payload":{
+                "revision":2,
+                "blocks":[block("self:flood-2","self","second","",true)]
+            }})
+            .to_string()
+            .into(),
+        ))
+        .await
+        .unwrap();
+        let waited = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let submits = server_state
+                    .operations
+                    .lock()
+                    .unwrap()
+                    .iter()
+                    .filter(|operation| operation.starts_with("submit"))
+                    .count();
+                if submits >= 2 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await;
+        assert!(
+            waited.is_ok(),
+            "second snapshot submit starved by OpenVR event flood"
+        );
+        ws.send(Message::Text(json!({"type":"shutdown"}).to_string().into()))
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    });
+    let mut manifest = test_manifest();
+    manifest.bridge_url = format!("ws://{address}");
+    let (mut bridge, snapshot) = BridgeClient::connect(&manifest).await.unwrap();
+    let mut owner = NativePresentationOwner::new_with_retry_policy_for_test(
+        snapshot,
+        CaptionRenderer::new_for_test().unwrap(),
+        EventFloodSubmitter {
+            state: state.clone(),
+        },
+        Duration::from_millis(10),
+        Duration::from_millis(100),
+        2,
+    );
+
+    owner
+        .run(
+            &mut bridge,
+            &test_logger("openvr-event-flood-fairness").await,
+        )
+        .await
+        .unwrap();
+
+    assert!(state.poll_calls.load(Ordering::SeqCst) >= 1);
+    assert!(state.max_events_in_one_poll.load(Ordering::SeqCst) <= 8);
+    assert_eq!(
+        state
+            .operations
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|operation| operation.starts_with("submit"))
+            .count(),
+        2
+    );
+    assert!(owner.resources_released());
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn production_owner_overlay_hidden_reasserts_show_when_desired_visible() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let state = Arc::new(OwnedSubmitterState::default());
+    let server_state = state.clone();
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut ws = accept_async(stream).await.unwrap();
+        let _auth = ws.next().await.unwrap().unwrap();
+        ws.send(Message::Text(
+            json!({"type":"snapshot","payload":{
+                "revision":1,
+                "blocks":[block("self:hidden","self","visible","",true)]
+            }})
+            .to_string()
+            .into(),
+        ))
+        .await
+        .unwrap();
+        loop {
+            let message = ws.next().await.unwrap().unwrap();
+            if message.to_text().unwrap().contains("overlay_ready") {
+                break;
+            }
+        }
+        let waited = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let shows = server_state
+                    .operations
+                    .lock()
+                    .unwrap()
+                    .iter()
+                    .filter(|operation| **operation == "show")
+                    .count();
+                if shows >= 2 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await;
+        assert!(waited.is_ok(), "OverlayHidden did not reassert ShowOverlay");
+        ws.send(Message::Text(json!({"type":"shutdown"}).to_string().into()))
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    });
+    let mut manifest = test_manifest();
+    manifest.bridge_url = format!("ws://{address}");
+    let (mut bridge, snapshot) = BridgeClient::connect(&manifest).await.unwrap();
+    let mut owner = NativePresentationOwner::new_with_retry_policy_for_test(
+        snapshot,
+        CaptionRenderer::new_for_test().unwrap(),
+        OverlayHiddenSubmitter {
+            state: state.clone(),
+            shown: false,
+            hidden_emitted: false,
+        },
+        Duration::from_millis(10),
+        Duration::from_millis(100),
+        2,
+    );
+
+    owner
+        .run(
+            &mut bridge,
+            &test_logger("overlay-hidden-reassert-show").await,
+        )
+        .await
+        .unwrap();
+
+    let operations = state.operations.lock().unwrap().clone();
+    assert!(
+        operations.starts_with(&["submit:text", "show", "show"]),
+        "unexpected visibility operations: {operations:?}"
+    );
+    assert!(owner.resources_released());
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn production_owner_event_pump_preserves_idle_hide_tail() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let state = Arc::new(OwnedSubmitterState::default());
+    let server_state = state.clone();
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut ws = accept_async(stream).await.unwrap();
+        let _auth = ws.next().await.unwrap().unwrap();
+        ws.send(Message::Text(
+            json!({"type":"snapshot","payload":{
+                "revision":1,
+                "blocks":[block("self:tail","self","visible","",true)]
+            }})
+            .to_string()
+            .into(),
+        ))
+        .await
+        .unwrap();
+        loop {
+            let message = ws.next().await.unwrap().unwrap();
+            if message.to_text().unwrap().contains("overlay_ready") {
+                break;
+            }
+        }
+        ws.send(Message::Text(
+            json!({"type":"snapshot","payload":{
+                "revision":2,
+                "blocks":[]
+            }})
+            .to_string()
+            .into(),
+        ))
+        .await
+        .unwrap();
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if server_state
+                    .operations
+                    .lock()
+                    .unwrap()
+                    .iter()
+                    .any(|operation| *operation == "submit:empty")
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("empty snapshot was not submitted");
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        let mid_tail = server_state.operations.lock().unwrap().clone();
+        assert!(
+            !mid_tail.iter().any(|operation| *operation == "hide"),
+            "event pump hid overlay during idle-hide tail: {mid_tail:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(450)).await;
+        let after_tail = server_state.operations.lock().unwrap().clone();
+        assert!(
+            after_tail.iter().any(|operation| *operation == "hide"),
+            "overlay was not hidden after idle-hide tail: {after_tail:?}"
+        );
+        ws.send(Message::Text(json!({"type":"shutdown"}).to_string().into()))
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    });
+    let mut manifest = test_manifest();
+    manifest.bridge_url = format!("ws://{address}");
+    let (mut bridge, snapshot) = BridgeClient::connect(&manifest).await.unwrap();
+    let mut owner = NativePresentationOwner::new_with_retry_policy_for_test(
+        snapshot,
+        CaptionRenderer::new_for_test().unwrap(),
+        ObservedVisibilitySubmitter {
+            state: state.clone(),
+            observed: None,
+        },
+        Duration::from_millis(10),
+        Duration::from_millis(100),
+        2,
+    );
+
+    owner
+        .run(
+            &mut bridge,
+            &test_logger("event-pump-preserves-idle-hide-tail").await,
+        )
+        .await
+        .unwrap();
+
     assert!(owner.resources_released());
     server.await.unwrap();
 }

--- a/native/overlay/tests/runtime.rs
+++ b/native/overlay/tests/runtime.rs
@@ -24,6 +24,7 @@ use puripuly_heart_overlay::{
     QuietTailProfile, ReadinessOutcome, RenderedFrame, RuntimeFailure, SpatialReanchorOutcome,
     StartupError, EXPECTED_CONTRACT_VERSION, NATIVE_FRESH_RETRY_CADENCE,
     NATIVE_FRESH_RETRY_DEADLINE, NATIVE_FRESH_RETRY_MAX_COMPLETED,
+    NATIVE_READINESS_TIMEOUT_RETRY_MAX,
 };
 
 #[test]
@@ -31,6 +32,7 @@ fn native_fresh_retry_production_policy_matches_dd_002() {
     assert_eq!(NATIVE_FRESH_RETRY_CADENCE, Duration::from_millis(100));
     assert_eq!(NATIVE_FRESH_RETRY_DEADLINE, Duration::from_millis(500));
     assert_eq!(NATIVE_FRESH_RETRY_MAX_COMPLETED, 5);
+    assert_eq!(NATIVE_READINESS_TIMEOUT_RETRY_MAX, 5);
     assert_ne!(u64::MAX, 0);
 }
 
@@ -4366,6 +4368,143 @@ async fn production_owner_active_schedule_readiness_failure_is_terminal() {
         .runtime()
         .pending_presentation_causes_for_test()
         .is_empty());
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn production_owner_single_readiness_timeout_retries_without_submit_or_exit() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut ws = accept_async(stream).await.unwrap();
+        let _auth = ws.next().await.unwrap().unwrap();
+        ws.send(Message::Text(
+            json!({"type":"snapshot","payload":{
+                "revision":1,
+                "native_fresh_render_generations":{"peer":4},
+                "blocks":[block("peer:timeout","peer","text","",true)]
+            }})
+            .to_string()
+            .into(),
+        ))
+        .await
+        .unwrap();
+        loop {
+            let message = ws.next().await.unwrap().unwrap();
+            if message.to_text().unwrap().contains("overlay_ready") {
+                break;
+            }
+        }
+        ws.send(Message::Text(json!({"type":"shutdown"}).to_string().into()))
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    });
+    let mut manifest = test_manifest();
+    manifest.bridge_url = format!("ws://{address}");
+    let (mut bridge, snapshot) = BridgeClient::connect(&manifest).await.unwrap();
+    let renderer = CaptionRenderer::new_for_test().unwrap();
+    renderer.set_test_readiness_terminal_outcome_on_call(1, ReadinessOutcome::TimedOut);
+    let state = Arc::new(OwnedSubmitterState::default());
+    let mut owner = NativePresentationOwner::new_with_retry_policy_for_test(
+        snapshot,
+        renderer,
+        OwnedSubmitterProbe {
+            state: state.clone(),
+            fail_submit: false,
+            fail_on_submission: None,
+            submit_delay: Duration::ZERO,
+        },
+        Duration::from_millis(10),
+        Duration::from_millis(100),
+        2,
+    );
+
+    owner
+        .run(
+            &mut bridge,
+            &test_logger("single-readiness-timeout-retry").await,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        state
+            .operations
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|operation| operation.starts_with("submit"))
+            .count(),
+        1
+    );
+    assert!(owner.resources_released());
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn production_owner_consecutive_readiness_timeouts_escalate_without_submit() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut ws = accept_async(stream).await.unwrap();
+        let _auth = ws.next().await.unwrap().unwrap();
+        ws.send(Message::Text(
+            json!({"type":"snapshot","payload":{
+                "revision":1,
+                "native_fresh_render_generations":{"peer":4},
+                "blocks":[block("peer:timeouts","peer","text","",true)]
+            }})
+            .to_string()
+            .into(),
+        ))
+        .await
+        .unwrap();
+        tokio::time::sleep(Duration::from_millis(800)).await;
+    });
+    let mut manifest = test_manifest();
+    manifest.bridge_url = format!("ws://{address}");
+    let (mut bridge, snapshot) = BridgeClient::connect(&manifest).await.unwrap();
+    let renderer = CaptionRenderer::new_for_test().unwrap();
+    renderer.set_test_readiness_pending_yields(1_000_000);
+    let state = Arc::new(OwnedSubmitterState::default());
+    let mut owner = NativePresentationOwner::new_with_retry_policy_for_test(
+        snapshot,
+        renderer,
+        OwnedSubmitterProbe {
+            state: state.clone(),
+            fail_submit: false,
+            fail_on_submission: None,
+            submit_delay: Duration::ZERO,
+        },
+        Duration::from_millis(10),
+        Duration::from_millis(100),
+        2,
+    );
+    owner.set_max_consecutive_readiness_timeouts_for_test(2);
+
+    let failure = owner
+        .run(
+            &mut bridge,
+            &test_logger("consecutive-readiness-timeouts").await,
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(failure, RuntimeFailure::ReadinessTimedOut);
+    assert_eq!(
+        state
+            .operations
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|operation| operation.starts_with("submit"))
+            .count(),
+        0
+    );
+    assert!(owner.resources_released());
     server.await.unwrap();
 }
 

--- a/src/puripuly_heart/app/services/overlay/overlay_application.py
+++ b/src/puripuly_heart/app/services/overlay/overlay_application.py
@@ -627,9 +627,7 @@ class OverlayApplicationOwner:
             presenter = runtime.presenter
         if isinstance(presenter, OverlayPresenter):
             await presenter.discard_epoch_retry_intent()
-        await asyncio.sleep(
-            OVERLAY_TERMINAL_RESTART_BACKOFF_S * self._terminal_restart_attempts
-        )
+        await asyncio.sleep(OVERLAY_TERMINAL_RESTART_BACKOFF_S * self._terminal_restart_attempts)
         if self._ingress_stopped or not self.state_provider().overlay_intent_enabled:
             self._recovering_from_crash = False
             self._auto_restart_scheduled = False

--- a/src/puripuly_heart/app/services/overlay/overlay_application.py
+++ b/src/puripuly_heart/app/services/overlay/overlay_application.py
@@ -51,6 +51,8 @@ from .overlay_session_transition import (
 
 OVERLAY_STARTUP_TIMEOUT_MS = 15000
 OVERLAY_SHUTDOWN_GRACE_S = 0.05
+OVERLAY_TERMINAL_RESTART_MAX = 3
+OVERLAY_TERMINAL_RESTART_BACKOFF_S = 0.05
 OVERLAY_STEAMVR_FALLBACK_POLICY: Literal["retry_every_enable"] = "retry_every_enable"
 OVERLAY_FAILURE_REASONS = frozenset(
     {
@@ -155,6 +157,8 @@ class OverlayApplicationOwner:
     _state: str = field(init=False, default="off", repr=False)
     _failure_reason: str | None = field(init=False, default=None, repr=False)
     _auto_restart_scheduled: bool = field(init=False, default=False, repr=False)
+    _terminal_restart_attempts: int = field(init=False, default=0, repr=False)
+    _recovering_from_crash: bool = field(init=False, default=False, repr=False)
     _active_target: str | None = field(init=False, default=None, repr=False)
     _ingress_stopped: bool = field(init=False, default=False, repr=False)
     _transition_owner: OverlaySessionTransitionOwner = field(init=False, repr=False)
@@ -492,7 +496,9 @@ class OverlayApplicationOwner:
         if self._runtime is not runtime:
             raise RuntimeError("overlay start transition runtime is not current")
         self._active_target = target
-        self._auto_restart_scheduled = False
+        if not self._recovering_from_crash:
+            self._auto_restart_scheduled = False
+            self._terminal_restart_attempts = 0
         if self._state != "starting":
             self._transition_state("starting")
             self._notify_state()
@@ -535,6 +541,7 @@ class OverlayApplicationOwner:
             clock=self.clock,
             startup_timeout_ms=OVERLAY_STARTUP_TIMEOUT_MS,
             fallback_reason=self._fallback_owner.reason if self._fallback_owner.active else None,
+            recovering_from_crash=self._recovering_from_crash,
         )
 
     def record_lifecycle_trace(self, event: str, **fields: object) -> None:
@@ -591,6 +598,62 @@ class OverlayApplicationOwner:
                 overlay_instance_id=instance_id,
             ),
         )
+
+    def _should_restart_after_terminal_failure(self, manager: OverlayProcessManager) -> bool:
+        if not manager.restart_scheduled:
+            return False
+        if self._ingress_stopped:
+            return False
+        state = self.state_provider()
+        if not state.settings_available or not state.overlay_intent_enabled:
+            return False
+        return self._terminal_restart_attempts < OVERLAY_TERMINAL_RESTART_MAX
+
+    async def _restart_after_terminal_failure(
+        self,
+        *,
+        failure_reason: str | None,
+    ) -> None:
+        self._terminal_restart_attempts += 1
+        self._recovering_from_crash = True
+        self._auto_restart_scheduled = True
+        self._failure_reason = None
+        if self._state != "starting":
+            self._transition_state("starting")
+            self._notify_state()
+        presenter = None
+        runtime = self._runtime
+        if runtime is not None:
+            presenter = runtime.presenter
+        if isinstance(presenter, OverlayPresenter):
+            await presenter.discard_epoch_retry_intent()
+        await asyncio.sleep(
+            OVERLAY_TERMINAL_RESTART_BACKOFF_S * self._terminal_restart_attempts
+        )
+        if self._ingress_stopped or not self.state_provider().overlay_intent_enabled:
+            self._recovering_from_crash = False
+            self._auto_restart_scheduled = False
+            await self.teardown(preserve_presenter_state=True)
+            return
+        try:
+            status = await self._transition_owner.begin_start(
+                lambda: self._start_execution(replace_starting=True)
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            await self._fail_terminal_restart(failure_reason)
+            return
+        if status == "started":
+            return
+        if status == "already_active" and self._state == "connected":
+            return
+        await self._fail_terminal_restart(failure_reason)
+
+    async def _fail_terminal_restart(self, failure_reason: str | None) -> None:
+        self.on_start_failed(failure_reason)
+        await self.teardown(preserve_presenter_state=True)
+        await self.refresh_peer_dependencies()
 
     def attach_translation_diagnostics(self, diagnostics: object) -> None:
         owner = self.diagnostics_provider()
@@ -656,6 +719,11 @@ class OverlayApplicationOwner:
             if runtime is None or runtime.process_manager is not manager:
                 return
             if manager.state != "failed":
+                return
+            if self._should_restart_after_terminal_failure(manager):
+                await self._restart_after_terminal_failure(
+                    failure_reason=manager.failure_reason,
+                )
                 return
             self.on_start_failed(manager.failure_reason)
             await self.teardown(preserve_presenter_state=True)
@@ -723,6 +791,7 @@ class OverlayApplicationOwner:
     def on_start_failed(self, failure_reason: str | None) -> None:
         self._failure_reason = self.normalize_failure_reason(failure_reason)
         self._auto_restart_scheduled = False
+        self._recovering_from_crash = False
         self._transition_state("failed")
         self._notify_state()
 
@@ -834,6 +903,8 @@ class OverlayApplicationOwner:
     def mark_connected(self) -> None:
         self._failure_reason = None
         self._auto_restart_scheduled = False
+        self._recovering_from_crash = False
+        self._terminal_restart_attempts = 0
         self._transition_state("connected")
         self._notify_state()
 

--- a/src/puripuly_heart/app/services/overlay/overlay_generation_start.py
+++ b/src/puripuly_heart/app/services/overlay/overlay_generation_start.py
@@ -146,7 +146,10 @@ class OverlayGenerationStartOwner:
             presenter = cast(OverlayPresenter | None, runtime.presenter)
             overlay_instance_id = f"overlay-{self.instance_token_factory()}"
             runtime.set_overlay_instance_id(overlay_instance_id)
-            diagnostics = OverlayDiagnosticsRecorder(overlay_instance_id=overlay_instance_id)
+            diagnostics = OverlayDiagnosticsRecorder(
+                overlay_instance_id=overlay_instance_id,
+                logging_mode=effects.logging_mode(),
+            )
             runtime.attach_diagnostics(diagnostics)
             request = request_factory()
             effects.set_target(request.target)

--- a/src/puripuly_heart/app/services/overlay/overlay_generation_start.py
+++ b/src/puripuly_heart/app/services/overlay/overlay_generation_start.py
@@ -72,6 +72,7 @@ class OverlayGenerationStartRequest:
     clock: Clock
     startup_timeout_ms: int
     fallback_reason: str | None = None
+    recovering_from_crash: bool = False
 
     @property
     def desktop(self) -> bool:
@@ -176,7 +177,10 @@ class OverlayGenerationStartOwner:
             presenter = cast(OverlayPresenter, runtime.adopt_presenter(presenter))
             presenter.runtime_log_detailed = effects.log_runtime
             if not request.desktop:
-                await presenter.update_native_retry_ownership(False)
+                if request.recovering_from_crash:
+                    await presenter.discard_epoch_retry_intent()
+                else:
+                    await presenter.update_native_retry_ownership(False)
             await presenter.update_calibration(effects.calibration_snapshot())
             await presenter.update_display_preferences(
                 show_translation=request.config.show_translation,

--- a/src/puripuly_heart/app/wiring/wiring_local_asr_provider_runtime.py
+++ b/src/puripuly_heart/app/wiring/wiring_local_asr_provider_runtime.py
@@ -47,6 +47,7 @@ class ManagedSTTProviderFactory(ProviderRuntimeProviderFactoryPort):
     on_final_transcript_suppressed: FinalTranscriptSuppressedSink | None = None
     runtime_logging: SessionRuntimeLoggingService | None = None
     fault_profile_provider: FaultProfileProvider | None = None
+    event_ingress_observer: Callable[..., object] | None = None
 
     async def create(
         self,
@@ -80,6 +81,7 @@ class ManagedSTTProviderFactory(ProviderRuntimeProviderFactoryPort):
             on_final_transcript_suppressed=self.on_final_transcript_suppressed,
             runtime_logging=self.runtime_logging,
             stt_input_fault_profile_provider=self.fault_profile_provider,
+            event_ingress_observer=self.event_ingress_observer,
         )
         if request.session_options is not None:
             await provider.reconfigure_session_options(request.session_options)
@@ -93,6 +95,14 @@ class LocalASRProviderRuntimeFactory:
     clock: Clock
     state_changed: ProviderRuntimeStateChanged | None = None
     diagnostic_sink: ProviderRuntimeDiagnosticSink | None = None
+
+    def bind_stt_event_ingress_observer(
+        self,
+        observer: Callable[..., object] | None,
+    ) -> None:
+        factory = self.provider_factory
+        if isinstance(factory, ManagedSTTProviderFactory):
+            factory.event_ingress_observer = observer
 
     def create(
         self,

--- a/src/puripuly_heart/app/wiring/wiring_runtime_pipeline.py
+++ b/src/puripuly_heart/app/wiring/wiring_runtime_pipeline.py
@@ -64,6 +64,7 @@ from puripuly_heart.core.runtime.self_capture import SelfCaptureSessionOwner
 from puripuly_heart.core.runtime.stt_session_projection import SttSessionStateProjection
 from puripuly_heart.domain.events import UIEvent
 
+from .wiring_local_asr_provider_runtime import LocalASRProviderRuntimeFactory
 from .wiring_managed_account import ManagedOpenRouterReleaseRuntime
 from .wiring_managed_gemma import noop_managed_gemma_release
 from .wiring_provider_runtime import (
@@ -789,6 +790,7 @@ async def _compose_runtime_pipeline(
         config_snapshot=translation_runtime_configuration.snapshot,
         runtime_logging=runtime_logging,
     )
+    osc.stage_recorder = translation_diagnostics.record_chatbox_stage
     translation_output_projection = TranslationOutputProjectionOwner(
         output_runtime=output_runtime,
         ui_messages=TranslationUiMessageQueue(ui_events),
@@ -818,13 +820,19 @@ async def _compose_runtime_pipeline(
         on_child_terminal=callbacks.child_terminal,
         on_parent_closed=callbacks.parent_closed,
         on_parent_rejected=callbacks.parent_rejected,
+        predecessor_wait_observer=translation_diagnostics.record_translation_wait,
         output=callbacks,
         config_snapshot=translation_runtime_configuration.snapshot,
     )
     resources.translation_turns = translation_turns
     await translation_turns.close_channel_ingress("self")
     await translation_turns.close_channel_ingress("peer")
-    local_asr_runtime = local_asr_factory(secrets).create(
+    asr_factory = local_asr_factory(secrets)
+    if isinstance(asr_factory, LocalASRProviderRuntimeFactory):
+        asr_factory.bind_stt_event_ingress_observer(
+            translation_diagnostics.record_stt_ingress
+        )
+    local_asr_runtime = asr_factory.create(
         LocalASRProviderRuntimeCallbacks(
             self_event_handler=callbacks.self_event_handler,
             peer_event_handler=callbacks.peer_event_handler,

--- a/src/puripuly_heart/app/wiring/wiring_runtime_pipeline.py
+++ b/src/puripuly_heart/app/wiring/wiring_runtime_pipeline.py
@@ -829,9 +829,7 @@ async def _compose_runtime_pipeline(
     await translation_turns.close_channel_ingress("peer")
     asr_factory = local_asr_factory(secrets)
     if isinstance(asr_factory, LocalASRProviderRuntimeFactory):
-        asr_factory.bind_stt_event_ingress_observer(
-            translation_diagnostics.record_stt_ingress
-        )
+        asr_factory.bind_stt_event_ingress_observer(translation_diagnostics.record_stt_ingress)
     local_asr_runtime = asr_factory.create(
         LocalASRProviderRuntimeCallbacks(
             self_event_handler=callbacks.self_event_handler,

--- a/src/puripuly_heart/core/orchestrator/peer_translation_channel.py
+++ b/src/puripuly_heart/core/orchestrator/peer_translation_channel.py
@@ -393,6 +393,13 @@ class PeerTranslationChannelOwner:
 
     async def handle_stt_event(self, event: object) -> None:
         self._require_ingress()
+        utterance_id = getattr(event, "utterance_id", None)
+        self.diagnostics.record_stt_ingress(
+            "stt_handler_start",
+            channel="peer",
+            event_type=type(event).__name__,
+            utterance_id=None if utterance_id is None else str(utterance_id),
+        )
         if isinstance(event, STTSessionStateEvent):
             if event.channel != "peer":
                 raise ValueError("Peer translation owner received a non-Peer session event")

--- a/src/puripuly_heart/core/orchestrator/self_translation_channel.py
+++ b/src/puripuly_heart/core/orchestrator/self_translation_channel.py
@@ -219,6 +219,13 @@ class SelfTranslationChannelOwner:
 
     async def handle_stt_event(self, event: object) -> None:
         self._require_ingress()
+        utterance_id = getattr(event, "utterance_id", None)
+        self.diagnostics.record_stt_ingress(
+            "stt_handler_start",
+            channel="self",
+            event_type=type(event).__name__,
+            utterance_id=None if utterance_id is None else str(utterance_id),
+        )
         low_latency_mode = self.config_snapshot().value.low_latency_mode
         if isinstance(event, STTSessionStateEvent):
             if event.channel != "self":

--- a/src/puripuly_heart/core/orchestrator/translation_diagnostics.py
+++ b/src/puripuly_heart/core/orchestrator/translation_diagnostics.py
@@ -400,6 +400,24 @@ class TranslationLatencyDiagnosticsOwner:
             )
         )
 
+    def record_chatbox_stage(self, event: str, **fields: object) -> None:
+        recorder = self.overlay_diagnostics
+        if recorder is None:
+            return
+        recorder.record_chatbox(event, **fields)
+
+    def record_translation_wait(self, event: str, fields: dict[str, object]) -> None:
+        recorder = self.overlay_diagnostics
+        if recorder is None:
+            return
+        recorder.record_translation(event, **fields)
+
+    def record_stt_ingress(self, event: str, **fields: object) -> None:
+        recorder = self.overlay_diagnostics
+        if recorder is None:
+            return
+        recorder.record_stt(event, **fields)
+
     def record_latency_stage(self, diagnostic: LatencyStageDiagnostic) -> None:
         timeline = self._get_timeline(
             diagnostic.channel,

--- a/src/puripuly_heart/core/orchestrator/translation_turn.py
+++ b/src/puripuly_heart/core/orchestrator/translation_turn.py
@@ -136,6 +136,8 @@ class _TranslationTurnParent:
     channel: ChannelId
     children: tuple[TranslationTurnChild, ...]
     completed_child_ids: set[UUID] = field(default_factory=set)
+    semantic_completed_child_ids: set[UUID] = field(default_factory=set)
+    semantic_done_event: asyncio.Event = field(default_factory=asyncio.Event)
     closed_event: asyncio.Event = field(default_factory=asyncio.Event)
     closed: bool = False
 
@@ -215,7 +217,9 @@ class TranslationTurnLifecycleOwner:
                 "child tasks",
                 "parent/child terminal state",
             ),
-            "ordering": "submission FIFO within each channel",
+            "ordering": (
+                "same-channel LLM admission waits on predecessor semantic completion"
+            ),
             "stop_ingress": "stop accepting translation turns",
             "shutdown_policy": "cancel parent tasks, terminalize unfinished children, await scope",
             "late_callback_rule": "closed parents reject child completion and output submission",
@@ -437,7 +441,7 @@ class TranslationTurnLifecycleOwner:
                     parent=parent,
                     predecessor=predecessor,
                 )
-                await predecessor.closed_event.wait()
+                await predecessor.semantic_done_event.wait()
                 self._observe_predecessor_wait(
                     "predecessor_wait_end",
                     parent=parent,
@@ -449,7 +453,7 @@ class TranslationTurnLifecycleOwner:
                 if self.is_child_cancellation_requested(child):
                     await self._terminalize_child(child, "cancelled")
                     continue
-                await self._run_child(child)
+                await self._run_child(child, predecessor)
         except asyncio.CancelledError:
             await self._terminalize_parent_remaining(parent, "cancelled")
             raise
@@ -478,10 +482,14 @@ class TranslationTurnLifecycleOwner:
             },
         )
 
-    async def _run_child(self, child: TranslationTurnChild) -> None:
+    async def _run_child(
+        self,
+        child: TranslationTurnChild,
+        predecessor: _TranslationTurnParent | None,
+    ) -> None:
         child_task = start_lifecycle_task(
             self._scope,
-            self._execute_started_child(child),
+            self._execute_started_child(child, predecessor),
             name=f"child:{child.utterance_id}",
             eager_start=True,
         )
@@ -505,21 +513,26 @@ class TranslationTurnLifecycleOwner:
     async def _execute_started_child(
         self,
         child: TranslationTurnChild,
+        predecessor: _TranslationTurnParent | None,
     ) -> TranslationTurnProcessResult:
         child_task = asyncio.current_task()
         if child_task is None:
             raise RuntimeError("translation child task is unavailable")
         await self.on_child_started(child, child_task)
-        return await self._execute_child(child)
+        return await self._execute_child(child, predecessor)
 
     async def _execute_child(
         self,
         child: TranslationTurnChild,
+        predecessor: _TranslationTurnParent | None,
     ) -> TranslationTurnProcessResult:
         result = await self._process_child(child)
         if self.is_child_cancellation_requested(child):
             await self._terminalize_child(child, "cancelled")
             raise asyncio.CancelledError
+        self._mark_child_semantic_done(child)
+        if predecessor is not None:
+            await predecessor.closed_event.wait()
         if result.output is not None and self.output is not None:
             try:
                 await self.output.submit_translation_output(result.output)
@@ -530,6 +543,14 @@ class TranslationTurnLifecycleOwner:
                 result = TranslationTurnProcessResult("failed")
         await self._terminalize_child(child, result.outcome)
         return result
+
+    def _mark_child_semantic_done(self, child: TranslationTurnChild) -> None:
+        parent = self._parents.get(child.parent_utterance_id)
+        if parent is None or parent.closed:
+            return
+        parent.semantic_completed_child_ids.add(child.utterance_id)
+        if parent.semantic_completed_child_ids == set(parent.child_ids):
+            parent.semantic_done_event.set()
 
     async def _process_child(self, child: TranslationTurnChild) -> TranslationTurnProcessResult:
         try:
@@ -589,6 +610,7 @@ class TranslationTurnLifecycleOwner:
             logger.exception("translation child terminal adapter failed")
         finally:
             parent.completed_child_ids.add(child.utterance_id)
+            self._mark_child_semantic_done(child)
             if parent.completed_child_ids == set(parent.child_ids):
                 await self._close_parent(parent)
 
@@ -607,6 +629,7 @@ class TranslationTurnLifecycleOwner:
             except Exception:
                 logger.exception("translation parent closure adapter failed")
         finally:
+            parent.semantic_done_event.set()
             parent.closed_event.set()
 
 

--- a/src/puripuly_heart/core/orchestrator/translation_turn.py
+++ b/src/puripuly_heart/core/orchestrator/translation_turn.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
 from typing import Literal, Protocol
 from uuid import UUID, uuid5
@@ -166,6 +166,7 @@ class TranslationTurnLifecycleOwner:
     on_child_terminal: ChildTerminal
     on_parent_closed: ParentClosed
     on_parent_rejected: ParentRejected
+    predecessor_wait_observer: Callable[[str, Mapping[str, object]], None] | None = None
     output: TranslationOutputSubmissionPort | None = None
     config_snapshot: TranslationRuntimeConfigSnapshotPort = _default_config_snapshot
     policy: TranslationRuntimePolicy = field(default_factory=TranslationRuntimePolicy)
@@ -431,7 +432,17 @@ class TranslationTurnLifecycleOwner:
     ) -> None:
         try:
             if predecessor is not None:
+                self._observe_predecessor_wait(
+                    "predecessor_wait_start",
+                    parent=parent,
+                    predecessor=predecessor,
+                )
                 await predecessor.closed_event.wait()
+                self._observe_predecessor_wait(
+                    "predecessor_wait_end",
+                    parent=parent,
+                    predecessor=predecessor,
+                )
             for child in parent.children:
                 if child.utterance_id in parent.completed_child_ids:
                     continue
@@ -447,6 +458,25 @@ class TranslationTurnLifecycleOwner:
             await self._terminalize_parent_remaining(parent, "failed")
         finally:
             self._parent_tasks.pop(parent.parent_utterance_id, None)
+
+    def _observe_predecessor_wait(
+        self,
+        event: str,
+        *,
+        parent: _TranslationTurnParent,
+        predecessor: _TranslationTurnParent,
+    ) -> None:
+        if self.predecessor_wait_observer is None:
+            return
+        self.predecessor_wait_observer(
+            event,
+            {
+                "channel": parent.channel,
+                "parent_utterance_id": str(parent.parent_utterance_id),
+                "predecessor_utterance_id": str(predecessor.parent_utterance_id),
+                "active_parent_count": len(self._parents),
+            },
+        )
 
     async def _run_child(self, child: TranslationTurnChild) -> None:
         child_task = start_lifecycle_task(

--- a/src/puripuly_heart/core/orchestrator/translation_turn.py
+++ b/src/puripuly_heart/core/orchestrator/translation_turn.py
@@ -217,9 +217,7 @@ class TranslationTurnLifecycleOwner:
                 "child tasks",
                 "parent/child terminal state",
             ),
-            "ordering": (
-                "same-channel LLM admission waits on predecessor semantic completion"
-            ),
+            "ordering": ("same-channel LLM admission waits on predecessor semantic completion"),
             "stop_ingress": "stop accepting translation turns",
             "shutdown_policy": "cancel parent tasks, terminalize unfinished children, await scope",
             "late_callback_rule": "closed parents reject child completion and output submission",

--- a/src/puripuly_heart/core/osc/chatbox_paginator.py
+++ b/src/puripuly_heart/core/osc/chatbox_paginator.py
@@ -28,9 +28,13 @@ class ChatboxPaginator:
     max_chars: int = 144
     page_interval_s: float = 3.0
     runtime_logging: SessionRuntimeLoggingService | None = None
+    stage_recorder: Callable[..., object] | None = None
     _pending_pages: list[str] | None = None
     _pending_messages: list[OSCMessage] | None = None
     _next_page_at: float = 0.0
+    _active_message: OSCMessage | None = field(default=None, init=False, repr=False)
+    _active_page_index: int = field(default=0, init=False, repr=False)
+    _active_page_count: int = field(default=0, init=False, repr=False)
     _typing_reasons: set[str] = field(default_factory=set, init=False, repr=False)
     _legacy_typing_active: bool = field(default=False, init=False, repr=False)
     _last_typing_state: bool = field(default=False, init=False, repr=False)
@@ -44,9 +48,24 @@ class ChatboxPaginator:
         self._pending_messages = []
 
     def enqueue(self, message: OSCMessage) -> None:
+        page_count = len(self._split_text(message.text.strip())) if message.text.strip() else 0
         if self._is_paginating():
             self._pending_messages.append(message)
+            self._record_stage(
+                "message_enqueue",
+                utterance_id=str(message.utterance_id),
+                text_len=len(message.text),
+                page_count=page_count,
+                started=False,
+            )
             return
+        self._record_stage(
+            "message_enqueue",
+            utterance_id=str(message.utterance_id),
+            text_len=len(message.text),
+            page_count=page_count,
+            started=True,
+        )
         self._start_message(message)
 
     def process_due(self) -> None:
@@ -60,6 +79,7 @@ class ChatboxPaginator:
 
         page = self._pending_pages.pop(0)
         remaining_parts = len(self._pending_pages)
+        self._active_page_index += 1
         self._send_page(mode="queued", text=page, remaining_parts=remaining_parts)
 
         if self._pending_pages:
@@ -67,6 +87,9 @@ class ChatboxPaginator:
             return
 
         self._next_page_at = 0.0
+        self._active_message = None
+        self._active_page_index = 0
+        self._active_page_count = 0
         self._drain_pending_messages()
 
     def send_immediate(self, text: str) -> bool:
@@ -128,6 +151,9 @@ class ChatboxPaginator:
         self._pending_pages.clear()
         self._pending_messages.clear()
         self._next_page_at = 0.0
+        self._active_message = None
+        self._active_page_index = 0
+        self._active_page_count = 0
         self._emit_basic(
             "[Basic][OSC] chatbox backlog dropped on output shutdown "
             f"pages={dropped_pages} messages={dropped_messages}"
@@ -144,6 +170,9 @@ class ChatboxPaginator:
         parts = self._split_text(text)
         head = parts[0]
         tail = parts[1:]
+        self._active_message = message
+        self._active_page_index = 0
+        self._active_page_count = len(parts)
         self._send_page(mode="queued", text=head, remaining_parts=len(tail))
 
         if tail:
@@ -173,7 +202,42 @@ class ChatboxPaginator:
             self._emit_send_failure(mode=mode, exc=exc)
             return False
         self._emit_send_delivered(mode=mode, text=text, remaining_parts=remaining_parts)
+        if mode == "queued":
+            active = self._active_message
+            self._record_stage(
+                "page_send",
+                utterance_id=None if active is None else str(active.utterance_id),
+                page_index=self._active_page_index,
+                page_count=self._active_page_count,
+                remaining_parts=remaining_parts,
+                text_len=len(text),
+            )
         return True
+
+    def _record_stage(self, event: str, **fields: object) -> None:
+        if self.stage_recorder is None:
+            return
+        now = self.clock.now()
+        pending = self._pending_messages or []
+        oldest_created = min(
+            (message.created_at for message in pending),
+            default=None,
+        )
+        if self._active_message is not None:
+            oldest_created = (
+                self._active_message.created_at
+                if oldest_created is None
+                else min(oldest_created, self._active_message.created_at)
+            )
+        self.stage_recorder(
+            event,
+            pending_messages=len(pending),
+            pending_pages=0 if self._pending_pages is None else len(self._pending_pages),
+            oldest_age_s=(
+                None if oldest_created is None else round(max(0.0, now - oldest_created), 3)
+            ),
+            **fields,
+        )
 
     def _emit_send_attempt(self, *, mode: str, text: str, remaining_parts: int) -> None:
         self._emit_detailed(

--- a/src/puripuly_heart/core/overlay/bridge.py
+++ b/src/puripuly_heart/core/overlay/bridge.py
@@ -260,19 +260,32 @@ class OverlayBridge:
         return asyncio.create_task(coroutine, name=f"OverlayBridge:{task_name}")
 
     async def _broadcast_json(self, payload: dict[str, Any]) -> None:
+        payload_type = str(payload.get("type"))
+        revision: int | None = None
+        block_update_ids: list[str] = []
+        if payload_type == "snapshot":
+            revision = payload.get("payload", {}).get("revision")  # type: ignore[assignment]
+            block_update_ids = self._snapshot_block_update_ids(payload)
         if not self._authenticated_connections:
+            if payload_type == "snapshot" and self.diagnostics is not None:
+                self.diagnostics.record_bridge(
+                    "snapshot_stored_unsent",
+                    revision=revision,
+                    authenticated_connections=0,
+                )
             return
 
         message = json.dumps(payload)
-        revision: int | None = None
-        block_update_ids: list[str] = []
-        if payload.get("type") == "snapshot":
-            revision = payload.get("payload", {}).get("revision")  # type: ignore[assignment]
-            block_update_ids = self._snapshot_block_update_ids(payload)
         start_time = time.perf_counter()
+        if payload_type == "snapshot" and self.diagnostics is not None:
+            self.diagnostics.record_bridge(
+                "send_start",
+                revision=revision,
+                authenticated_connections=len(self._authenticated_connections),
+            )
         self._log_broadcast_marker(
             stage="start",
-            payload_type=str(payload.get("type")),
+            payload_type=payload_type,
             revision=revision,
             block_update_ids=block_update_ids,
             authenticated_connections=len(self._authenticated_connections),
@@ -302,14 +315,23 @@ class OverlayBridge:
         for connection in stale_connections:
             self._authenticated_connections.discard(connection)
 
+        elapsed_ms = max(0, int((time.perf_counter() - start_time) * 1000))
+        if payload_type == "snapshot" and self.diagnostics is not None:
+            self.diagnostics.record_bridge(
+                "send_finish",
+                revision=revision,
+                authenticated_connections=len(self._authenticated_connections),
+                stale_connections=len(stale_connections),
+                elapsed_ms=elapsed_ms,
+            )
         self._log_broadcast_marker(
             stage="finish",
-            payload_type=str(payload.get("type")),
+            payload_type=payload_type,
             revision=revision,
             block_update_ids=block_update_ids,
             authenticated_connections=len(self._authenticated_connections),
             stale_connections=len(stale_connections),
-            elapsed_ms=max(0, int((time.perf_counter() - start_time) * 1000)),
+            elapsed_ms=elapsed_ms,
         )
 
     def _snapshot_block_update_ids(self, payload: dict[str, Any]) -> list[str]:

--- a/src/puripuly_heart/core/overlay/diagnostics.py
+++ b/src/puripuly_heart/core/overlay/diagnostics.py
@@ -15,6 +15,8 @@ from puripuly_heart.core.diagnostic_validation import (
     DIAGNOSTIC_VALIDATION_STATUS_ACCEPTED,
     redact_text_for_sink,
 )
+from puripuly_heart.core.overlay.manifest import normalize_overlay_logging_mode
+from puripuly_heart.core.runtime_logging import SessionLoggingMode
 
 _PROCESS_EVENT_LIMIT = 256
 _CHILD_LINE_LIMIT = 100
@@ -86,6 +88,7 @@ def _redact_failure_jsonl_text(text: str) -> str:
 class OverlayDiagnosticsRecorder:
     overlay_instance_id: str
     diagnostics_dir: Path = field(default_factory=default_overlay_diagnostics_dir)
+    logging_mode: str = SessionLoggingMode.BASIC.value
 
     process_events: deque[dict[str, Any]] = field(
         default_factory=lambda: deque(maxlen=_PROCESS_EVENT_LIMIT)
@@ -122,6 +125,15 @@ class OverlayDiagnosticsRecorder:
     _sequence: int = field(init=False, default=0)
     _started_at: float = field(init=False, default_factory=time.monotonic)
 
+    def __post_init__(self) -> None:
+        self.set_logging_mode(self.logging_mode)
+
+    def set_logging_mode(self, mode: SessionLoggingMode | str | bool | object) -> None:
+        normalized = normalize_overlay_logging_mode(mode)
+        if normalized != SessionLoggingMode.DETAILED.value:
+            self._clear_stage_events()
+        self.logging_mode = normalized
+
     def record_process(self, event: str, **fields: Any) -> dict[str, Any]:
         return self._append(self.process_events, category="process", event=event, **fields)
 
@@ -132,12 +144,14 @@ class OverlayDiagnosticsRecorder:
         )
 
     def record_presenter(self, event: str, **fields: Any) -> dict[str, Any]:
-        return self._append(self.presenter_events, category="presenter", event=event, **fields)
+        return self._append_stage(
+            self.presenter_events, category="presenter", event=event, **fields
+        )
 
     def record_presenter_removal(
         self, event: str = "entry_removed", **fields: Any
     ) -> dict[str, Any]:
-        return self._append(
+        return self._append_stage(
             self.presenter_removal_events,
             category="presenter_removal",
             event=event,
@@ -145,23 +159,25 @@ class OverlayDiagnosticsRecorder:
         )
 
     def record_bridge(self, event: str, **fields: Any) -> dict[str, Any]:
-        return self._append(self.bridge_events, category="bridge", event=event, **fields)
+        return self._append_stage(self.bridge_events, category="bridge", event=event, **fields)
 
     def record_translation(self, event: str, **fields: Any) -> dict[str, Any]:
-        return self._append(
+        return self._append_stage(
             self.translation_events, category="translation", event=event, **fields
         )
 
     def record_chatbox(self, event: str, **fields: Any) -> dict[str, Any]:
-        return self._append(self.chatbox_events, category="chatbox", event=event, **fields)
+        return self._append_stage(self.chatbox_events, category="chatbox", event=event, **fields)
 
     def record_stt(self, event: str, **fields: Any) -> dict[str, Any]:
-        return self._append(self.stt_events, category="stt", event=event, **fields)
+        return self._append_stage(self.stt_events, category="stt", event=event, **fields)
 
     def record_native(self, event: str, **fields: Any) -> dict[str, Any]:
-        return self._append(self.native_events, category="native", event=event, **fields)
+        return self._append_stage(self.native_events, category="native", event=event, **fields)
 
     def ingest_native_child_line(self, line: str) -> bool:
+        if not self._stage_recording_enabled():
+            return False
         marker_at = line.find(_PRESENTATION_DIAGNOSTICS_MARKER)
         if marker_at < 0:
             return False
@@ -206,6 +222,30 @@ class OverlayDiagnosticsRecorder:
                 handle.write("\n")
         self.last_dump_path = path
         return path
+
+    def _stage_recording_enabled(self) -> bool:
+        return self.logging_mode == SessionLoggingMode.DETAILED.value
+
+    def _clear_stage_events(self) -> None:
+        self.presenter_events.clear()
+        self.presenter_removal_events.clear()
+        self.bridge_events.clear()
+        self.translation_events.clear()
+        self.chatbox_events.clear()
+        self.stt_events.clear()
+        self.native_events.clear()
+
+    def _append_stage(
+        self,
+        target: deque[dict[str, Any]],
+        *,
+        category: str,
+        event: str,
+        **fields: Any,
+    ) -> dict[str, Any]:
+        if not self._stage_recording_enabled():
+            return {}
+        return self._append(target, category=category, event=event, **fields)
 
     def _append(
         self,

--- a/src/puripuly_heart/core/overlay/diagnostics.py
+++ b/src/puripuly_heart/core/overlay/diagnostics.py
@@ -22,6 +22,10 @@ _PRESENTER_SNAPSHOT_LIMIT = 30
 _PRESENTER_REMOVAL_LIMIT = 50
 _BRIDGE_EVENT_LIMIT = 30
 _TRANSLATION_EVENT_LIMIT = 50
+_CHATBOX_EVENT_LIMIT = 50
+_STT_EVENT_LIMIT = 50
+_NATIVE_EVENT_LIMIT = 50
+_PRESENTATION_DIAGNOSTICS_MARKER = "presentation_diagnostics "
 _SENSITIVE_DIAGNOSTIC_FIELD_KEYS = {
     "accesstoken",
     "apikey",
@@ -104,6 +108,15 @@ class OverlayDiagnosticsRecorder:
     translation_events: deque[dict[str, Any]] = field(
         default_factory=lambda: deque(maxlen=_TRANSLATION_EVENT_LIMIT)
     )
+    chatbox_events: deque[dict[str, Any]] = field(
+        default_factory=lambda: deque(maxlen=_CHATBOX_EVENT_LIMIT)
+    )
+    stt_events: deque[dict[str, Any]] = field(
+        default_factory=lambda: deque(maxlen=_STT_EVENT_LIMIT)
+    )
+    native_events: deque[dict[str, Any]] = field(
+        default_factory=lambda: deque(maxlen=_NATIVE_EVENT_LIMIT)
+    )
     last_dump_path: Path | None = None
 
     _sequence: int = field(init=False, default=0)
@@ -119,22 +132,62 @@ class OverlayDiagnosticsRecorder:
         )
 
     def record_presenter(self, event: str, **fields: Any) -> dict[str, Any]:
-        _ = (event, fields)
-        return {}
+        return self._append(self.presenter_events, category="presenter", event=event, **fields)
 
     def record_presenter_removal(
         self, event: str = "entry_removed", **fields: Any
     ) -> dict[str, Any]:
-        _ = (event, fields)
-        return {}
+        return self._append(
+            self.presenter_removal_events,
+            category="presenter_removal",
+            event=event,
+            **fields,
+        )
 
     def record_bridge(self, event: str, **fields: Any) -> dict[str, Any]:
-        _ = (event, fields)
-        return {}
+        return self._append(self.bridge_events, category="bridge", event=event, **fields)
 
     def record_translation(self, event: str, **fields: Any) -> dict[str, Any]:
-        _ = (event, fields)
-        return {}
+        return self._append(
+            self.translation_events, category="translation", event=event, **fields
+        )
+
+    def record_chatbox(self, event: str, **fields: Any) -> dict[str, Any]:
+        return self._append(self.chatbox_events, category="chatbox", event=event, **fields)
+
+    def record_stt(self, event: str, **fields: Any) -> dict[str, Any]:
+        return self._append(self.stt_events, category="stt", event=event, **fields)
+
+    def record_native(self, event: str, **fields: Any) -> dict[str, Any]:
+        return self._append(self.native_events, category="native", event=event, **fields)
+
+    def ingest_native_child_line(self, line: str) -> bool:
+        marker_at = line.find(_PRESENTATION_DIAGNOSTICS_MARKER)
+        if marker_at < 0:
+            return False
+        raw = line[marker_at + len(_PRESENTATION_DIAGNOSTICS_MARKER) :].strip()
+        try:
+            records = json.loads(raw)
+        except json.JSONDecodeError:
+            return False
+        if not isinstance(records, list):
+            return False
+        ingested = False
+        for record in records:
+            if not isinstance(record, dict):
+                continue
+            self.record_native(
+                str(record.get("stage") or "presentation"),
+                logical_revision=record.get("logical_revision"),
+                outcome=record.get("outcome"),
+                readiness_us=record.get("readiness_us"),
+                cached_visibility=record.get("observed_runtime_visible"),
+                desired_visible=record.get("desired_visible"),
+                actual_visibility="not_queried",
+                physical_hmd_visibility=record.get("physical_hmd_visibility"),
+            )
+            ingested = True
+        return ingested
 
     def dump_failure(self, **summary_fields: Any) -> Path:
         self.diagnostics_dir.mkdir(parents=True, exist_ok=True)
@@ -193,3 +246,10 @@ class OverlayDiagnosticsRecorder:
         yield from self.process_events
         yield from self.child_stdout_lines
         yield from self.child_stderr_lines
+        yield from self.presenter_events
+        yield from self.presenter_removal_events
+        yield from self.bridge_events
+        yield from self.translation_events
+        yield from self.chatbox_events
+        yield from self.stt_events
+        yield from self.native_events

--- a/src/puripuly_heart/core/overlay/presenter.py
+++ b/src/puripuly_heart/core/overlay/presenter.py
@@ -556,9 +556,7 @@ class OverlayPresenter(OverlaySink):
     async def discard_epoch_retry_intent(self) -> None:
         async with self._ownership_transition_lock:
             await self._cancel_peer_presentation_refresh_burst_task_and_wait()
-            await self._cancel_self_presentation_refresh_burst_task_and_wait(
-                reason="epoch_discard"
-            )
+            await self._cancel_self_presentation_refresh_burst_task_and_wait(reason="epoch_discard")
             self.native_retry_trigger_emission = False
             self.peer_presentation_refresh_burst = False
             self.self_presentation_refresh_burst = False

--- a/src/puripuly_heart/core/overlay/presenter.py
+++ b/src/puripuly_heart/core/overlay/presenter.py
@@ -553,6 +553,30 @@ class OverlayPresenter(OverlaySink):
             ):
                 await self._publish_if_changed()
 
+    async def discard_epoch_retry_intent(self) -> None:
+        async with self._ownership_transition_lock:
+            await self._cancel_peer_presentation_refresh_burst_task_and_wait()
+            await self._cancel_self_presentation_refresh_burst_task_and_wait(
+                reason="epoch_discard"
+            )
+            self.native_retry_trigger_emission = False
+            self.peer_presentation_refresh_burst = False
+            self.self_presentation_refresh_burst = False
+            self._native_fresh_render_generations = NativeFreshRenderGenerations()
+            self._native_fresh_render_targets = NativeFreshRenderTargets()
+            self._native_quiet_tail_episodes = NativeQuietTailEpisodes()
+            self._native_quiet_tail_self_target = None
+            self._native_quiet_tail_peer_target = None
+            self._native_quiet_tail_self_generation = None
+            self._native_quiet_tail_peer_generation = None
+            peer_refresh_key = self._presentation_state.peer_presentation_refresh_target_key
+            if peer_refresh_key is not None:
+                self._presentation_state.end_peer_presentation_refresh(peer_refresh_key)
+            self_refresh_key = self._presentation_state.self_presentation_refresh_target_key
+            if self_refresh_key is not None:
+                self._presentation_state.end_self_presentation_refresh(self_refresh_key)
+            await self._publish_if_changed(force_protocol_publish=True)
+
     async def update_native_retry_ownership(self, confirmed: bool) -> None:
         async with self._ownership_transition_lock:
             await self._update_native_retry_ownership_serialized(confirmed)

--- a/src/puripuly_heart/core/overlay/process.py
+++ b/src/puripuly_heart/core/overlay/process.py
@@ -1402,7 +1402,8 @@ class OverlayProcessManager:
     ) -> None:
         self.state = "failed"
         self.failure_reason = failure_reason
-        self.restart_scheduled = False
+        connected_session = self._last_transition in {"overlay_ready", "bridge_ready"}
+        self.restart_scheduled = connected_session and not self._shutdown_requested
         self._current_phase = "failed"
         stdout_count = (
             len(self.diagnostics.child_stdout_lines) if self.diagnostics is not None else 0

--- a/src/puripuly_heart/core/overlay/process.py
+++ b/src/puripuly_heart/core/overlay/process.py
@@ -549,10 +549,15 @@ class OverlayProcessManager:
             self.diagnostics = OverlayDiagnosticsRecorder(
                 overlay_instance_id=self.overlay_instance_id,
                 diagnostics_dir=self.diagnostics_dir,
+                logging_mode=self.logging_mode,
             )
+        else:
+            self.diagnostics.set_logging_mode(self.logging_mode)
 
     def set_logging_mode(self, mode: str) -> None:
         self.logging_mode = normalize_overlay_logging_mode(mode)
+        if self.diagnostics is not None:
+            self.diagnostics.set_logging_mode(self.logging_mode)
         process = self._process
         if process is not None:
             set_logging_mode = getattr(process, "set_logging_mode", None)

--- a/src/puripuly_heart/core/overlay/process.py
+++ b/src/puripuly_heart/core/overlay/process.py
@@ -192,12 +192,11 @@ class _AsyncioOverlayProcess:
                 if event is not None:
                     await self._events.put(event)
                     continue
-                if (
-                    line
-                    and self._diagnostics is not None
-                    and self._should_capture_failure_line(line, stream_name)
-                ):
-                    self._diagnostics.record_child_line(stream_name, line)
+                if line and self._diagnostics is not None:
+                    if self._diagnostics.ingest_native_child_line(line):
+                        pass
+                    elif self._should_capture_failure_line(line, stream_name):
+                        self._diagnostics.record_child_line(stream_name, line)
                 self._log_passthrough_line(line, stream_name)
         except asyncio.CancelledError:
             raise

--- a/src/puripuly_heart/core/stt/controller.py
+++ b/src/puripuly_heart/core/stt/controller.py
@@ -75,6 +75,7 @@ class ManagedSTTProvider:
     ) = None
     runtime_logging: SessionRuntimeLoggingService | None = None
     stt_input_fault_profile_provider: Callable[[], AudioFaultProfile | str | None] | None = None
+    event_ingress_observer: Callable[..., object] | None = None
 
     _state: STTSessionState = STTSessionState.DISCONNECTED
     _active_session: STTBackendSession | None = None
@@ -82,6 +83,7 @@ class ManagedSTTProvider:
     _consumer_task: asyncio.Task[None] | None = None
     _draining: set[asyncio.Task[None]] = field(default_factory=set)
     _events: asyncio.Queue = field(default_factory=asyncio.Queue)
+    _event_enqueued_at: deque[float] = field(default_factory=deque)
     _session_open_lock: asyncio.Lock = field(init=False, repr=False)
 
     _active_utterance_id: UUID | None = None
@@ -396,7 +398,10 @@ class ManagedSTTProvider:
             try:
                 self._events.get_nowait()
             except asyncio.QueueEmpty:
+                self._event_enqueued_at.clear()
                 return
+            if self._event_enqueued_at:
+                self._event_enqueued_at.popleft()
 
     async def handle_vad_event(self, event: VadEvent) -> None:
         if isinstance(event, SpeechStart):
@@ -410,11 +415,44 @@ class ManagedSTTProvider:
 
     async def events(self) -> AsyncIterator[object]:
         while True:
-            item = await self._events.get()
+            item = await self._take_event()
             if isinstance(item, _EventIngressBarrier):
                 item.reached.set()
                 continue
+            self._observe_event_ingress("stt_handler_start", item)
             yield item
+
+    def event_ingress_snapshot(self) -> dict[str, object]:
+        now = self.clock.now()
+        oldest = self._event_enqueued_at[0] if self._event_enqueued_at else None
+        return {
+            "queue_depth": self._events.qsize(),
+            "oldest_age_s": None if oldest is None else round(max(0.0, now - oldest), 3),
+        }
+
+    async def _publish_event(self, item: object) -> None:
+        await self._events.put(item)
+        if not isinstance(item, _EventIngressBarrier):
+            self._event_enqueued_at.append(self.clock.now())
+            self._observe_event_ingress("stt_enqueue", item)
+
+    async def _take_event(self) -> object:
+        item = await self._events.get()
+        if not isinstance(item, _EventIngressBarrier) and self._event_enqueued_at:
+            self._event_enqueued_at.popleft()
+        return item
+
+    def _observe_event_ingress(self, event: str, item: object) -> None:
+        if self.event_ingress_observer is None:
+            return
+        utterance_id = getattr(item, "utterance_id", None)
+        self.event_ingress_observer(
+            event,
+            channel=self.channel,
+            event_type=type(item).__name__,
+            utterance_id=None if utterance_id is None else str(utterance_id),
+            **self.event_ingress_snapshot(),
+        )
 
     @property
     def is_at_utterance_boundary(self) -> bool:
@@ -684,7 +722,7 @@ class ManagedSTTProvider:
                 fallback_level=logging.ERROR,
             )
             await self._set_state(STTSessionState.DISCONNECTED)
-            await self._events.put(
+            await self._publish_event(
                 STTErrorEvent(
                     message=report.message,
                     diagnostics=report.diagnostics,
@@ -1074,9 +1112,9 @@ class ManagedSTTProvider:
                     final_language_runs=ev.final_language_runs,
                 )
                 if ev.is_final:
-                    await self._events.put(STTFinalEvent(utterance_id, transcript))
+                    await self._publish_event(STTFinalEvent(utterance_id, transcript))
                 else:
-                    await self._events.put(STTPartialEvent(utterance_id, transcript))
+                    await self._publish_event(STTPartialEvent(utterance_id, transcript))
         except asyncio.CancelledError:
             raise
         except Exception as exc:
@@ -1123,7 +1161,7 @@ class ManagedSTTProvider:
             fallback_level=logging.ERROR,
         )
         if not self._closing:
-            await self._events.put(
+            await self._publish_event(
                 STTErrorEvent(
                     message=report.message,
                     diagnostics=report.diagnostics,
@@ -1141,7 +1179,7 @@ class ManagedSTTProvider:
             f"[STT] State: {old_state.name} -> {state.name}",
             fallback_level=logging.INFO,
         )
-        await self._events.put(STTSessionStateEvent(state, channel=self.channel))
+        await self._publish_event(STTSessionStateEvent(state, channel=self.channel))
 
     def _has_recent_speech(self) -> bool:
         """Check if speech ended recently within the reconnect window."""

--- a/src/puripuly_heart/ui/desktop_overlay_surface/renderer.py
+++ b/src/puripuly_heart/ui/desktop_overlay_surface/renderer.py
@@ -1000,9 +1000,11 @@ def _caption_slots_with_ui_cjk_font(
         replace(
             slot,
             lines=tuple(
-                replace(line, font_family=cjk_font_family)
-                if line.font_family == _DESKTOP_CAPTION_CJK_FONT_FAMILY
-                else line
+                (
+                    replace(line, font_family=cjk_font_family)
+                    if line.font_family == _DESKTOP_CAPTION_CJK_FONT_FAMILY
+                    else line
+                )
                 for line in slot.lines
             ),
         )

--- a/tests/app/test_overlay_application_transitions.py
+++ b/tests/app/test_overlay_application_transitions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from typing import cast
 
@@ -18,6 +19,8 @@ from puripuly_heart.app.services.peer_application import (
 from puripuly_heart.config.overlay_calibration import OverlayCalibration
 from puripuly_heart.config.resolved import ResolvedOverlayConfig
 from puripuly_heart.core.clock import FakeClock
+from puripuly_heart.core.overlay.presenter import OverlayPresenter
+from puripuly_heart.core.overlay.protocol import NativeFreshRenderGenerations
 from puripuly_heart.ui.overlay_peer_contract import (
     build_overlay_peer_consumer_contract_from_state,
 )
@@ -221,6 +224,18 @@ class SuccessfulStartTransition:
 class RaisingStartTransition:
     async def begin_start(self, _execution_factory) -> str:
         raise RuntimeError("fallback start failed")
+
+
+class RecordingStartTransition:
+    def __init__(self) -> None:
+        self.calls = 0
+        self.execution_state: str | None = None
+
+    async def begin_start(self, execution_factory) -> str:
+        self.calls += 1
+        execution = execution_factory()
+        self.execution_state = execution.state
+        return "started"
 
 
 def make_owner(recorder: Recorder) -> OverlayApplicationOwner:
@@ -445,3 +460,110 @@ async def test_fallback_teardown_failed_terminates_real_peer_activation() -> Non
 
     harness.assert_terminal_fallback_failure()
     assert harness.overlay.fallback_owner.task is None
+
+
+async def test_watch_runtime_restarts_connected_crash_and_keeps_peer_activation() -> None:
+    recorder = Recorder()
+    owner = make_owner(recorder)
+    runtime = owner.new_runtime()
+    manager = SimpleNamespace(
+        state="failed",
+        restart_scheduled=True,
+        failure_reason="runtime_crashed",
+    )
+    runtime.attach_process_manager(manager)
+    owner.state = "connected"
+    owner._transition_owner = cast(object, FixedStartTransition("started"))
+    monitor = asyncio.get_running_loop().create_future()
+    monitor.set_result(None)
+
+    await owner.watch_runtime(manager, monitor, runtime=runtime)
+
+    assert owner.auto_restart_scheduled is True
+    assert owner.state == "starting"
+    assert owner.failure_reason is None
+    assert recorder.cancel_peer_activation_calls == 0
+
+
+async def test_watch_runtime_does_not_restart_when_shutdown_was_not_scheduled() -> None:
+    recorder = Recorder()
+    owner = make_owner(recorder)
+    runtime = owner.new_runtime()
+    manager = SimpleNamespace(
+        state="failed",
+        restart_scheduled=False,
+        failure_reason="runtime_crashed",
+    )
+    runtime.attach_process_manager(manager)
+    owner.state = "connected"
+    monitor = asyncio.get_running_loop().create_future()
+    monitor.set_result(None)
+
+    await owner.watch_runtime(manager, monitor, runtime=runtime)
+
+    assert owner.auto_restart_scheduled is False
+    assert owner.state == "failed"
+    assert owner.failure_reason == "runtime_crashed"
+
+
+async def test_watch_runtime_restart_discards_old_epoch_retry_intent() -> None:
+    recorder = Recorder()
+    owner = make_owner(recorder)
+    runtime = owner.new_runtime()
+    presenter = OverlayPresenter(
+        calibration=OverlayCalibration(),
+        clock=FakeClock(_now=1.0),
+        native_retry_trigger_emission=True,
+        peer_presentation_refresh_burst=False,
+        self_presentation_refresh_burst=False,
+    )
+    presenter._native_fresh_render_generations = NativeFreshRenderGenerations(self=4)
+    await presenter._publish_if_changed(force_protocol_publish=True)
+    runtime.adopt_presenter(presenter)
+    manager = SimpleNamespace(
+        state="failed",
+        restart_scheduled=True,
+        failure_reason="runtime_crashed",
+    )
+    runtime.attach_process_manager(manager)
+    owner.state = "connected"
+    owner._transition_owner = cast(object, FixedStartTransition("started"))
+    monitor = asyncio.get_running_loop().create_future()
+    monitor.set_result(None)
+
+    await owner.watch_runtime(manager, monitor, runtime=runtime)
+
+    snapshot = presenter.snapshot()
+    assert snapshot.native_fresh_render_generations is None
+    assert snapshot.native_fresh_render_targets is None
+    assert presenter.native_retry_trigger_emission is False
+    assert owner.auto_restart_scheduled is True
+    assert owner.state == "starting"
+
+
+async def test_watch_runtime_restart_teardown_failure_fails_instead_of_staying_starting() -> None:
+    recorder = Recorder()
+    owner = make_owner(recorder)
+    runtime = owner.new_runtime()
+    manager = SimpleNamespace(
+        state="failed",
+        restart_scheduled=True,
+        failure_reason="runtime_crashed",
+    )
+    runtime.attach_process_manager(manager)
+    owner.state = "connected"
+    owner._transition_owner = cast(object, FixedStartTransition("teardown_failed"))
+    monitor = asyncio.get_running_loop().create_future()
+    monitor.set_result(None)
+
+    await owner.watch_runtime(manager, monitor, runtime=runtime)
+
+    assert owner.auto_restart_scheduled is False
+    assert owner.state == "failed"
+    assert owner.failure_reason == "runtime_crashed"
+
+    follow_up = RecordingStartTransition()
+    owner._transition_owner = cast(object, follow_up)
+    await owner.begin_start()
+    assert follow_up.calls == 1
+    assert follow_up.execution_state == "failed"

--- a/tests/app/test_overlay_generation_start_owner.py
+++ b/tests/app/test_overlay_generation_start_owner.py
@@ -39,6 +39,15 @@ class FakePresenter:
     async def update_native_retry_ownership(self, confirmed: bool) -> None:
         self.events.append(f"presenter:native_retry:{confirmed}")
 
+    async def discard_epoch_retry_intent(self) -> None:
+        self.events.append("presenter:discard_epoch")
+        if isinstance(self.snapshot_value, dict):
+            self.snapshot_value = {
+                key: value
+                for key, value in self.snapshot_value.items()
+                if key != "native_fresh_render_generations"
+            }
+
     async def update_calibration(self, calibration: OverlayCalibration) -> None:
         self.events.append(f"presenter:calibration:{calibration.distance}")
 
@@ -155,7 +164,12 @@ class StartHarness:
         FakeBridge.events = self.events
         FakeProcessManager.events = self.events
 
-    def request(self, *, desktop: bool) -> OverlayGenerationStartRequest:
+    def request(
+        self,
+        *,
+        desktop: bool,
+        recovering_from_crash: bool = False,
+    ) -> OverlayGenerationStartRequest:
         target = "desktop" if desktop else "steamvr"
         return OverlayGenerationStartRequest(
             config=ResolvedOverlayConfig(
@@ -167,6 +181,7 @@ class StartHarness:
                 desktop_overlay_options={},
             ),
             target=target,
+            recovering_from_crash=recovering_from_crash,
             clock=FakeClock(),
             startup_timeout_ms=3210,
         )
@@ -475,6 +490,41 @@ async def test_owner_propagates_cancellation_after_attaching_generation_resource
     assert runtime.bridge is FakeBridge.instances[0]
     assert harness.failure_reasons == []
     assert harness.owner_diagnostics[-1].outcome == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_owner_crash_recovery_discards_old_epoch_snapshot_before_new_process() -> None:
+    harness = StartHarness()
+    runtime = OverlayRuntimeHandle(shutdown_grace_s=0)
+    presenter = FakePresenter(
+        runtime_log_detailed=lambda message, *, level=logging.INFO: False,
+        diagnostics=None,
+        task_factory=runtime.create_child_task,
+    )
+    presenter.snapshot_value = {
+        "native_fresh_render_generations": {"self": 4},
+        "text": "keep this caption",
+    }
+    runtime.adopt_presenter(presenter)
+    owner = OverlayGenerationStartOwner(
+        diagnostic_sink=harness.owner_diagnostics.append,
+        instance_token_factory=lambda: "recovered",
+        session_token_factory=lambda: "new-session",
+    )
+
+    status = await owner.start(
+        runtime,
+        lambda: harness.request(desktop=False, recovering_from_crash=True),
+        harness.effects(),
+    )
+    await asyncio.sleep(0)
+
+    assert status == "connected"
+    assert "presenter:discard_epoch" in FakePresenter.events
+    assert "presenter:native_retry:False" not in FakePresenter.events
+    assert FakeBridge.instances[0].session_token == "new-session"
+    assert FakeBridge.instances[0].current_snapshot == {"text": "keep this caption"}
+    assert runtime.overlay_instance_id == "overlay-recovered"
 
 
 def test_owner_declares_generation_assembly_without_absorbing_resource_teardown() -> None:

--- a/tests/app/test_overlay_process_manager.py
+++ b/tests/app/test_overlay_process_manager.py
@@ -782,9 +782,7 @@ async def test_overlay_process_manager_maps_pre_ready_exit_code_to_standard_fail
 
 
 @pytest.mark.asyncio
-async def test_overlay_process_manager_maps_post_ready_exit_to_runtime_crashed_without_restart() -> (
-    None
-):
+async def test_overlay_process_manager_schedules_restart_after_connected_crash() -> None:
     manager = OverlayProcessManager(
         process_runner=FakeProcessRunner(ready_event_delay_ms=0, exit_after_ready_code=1)
     )
@@ -793,7 +791,7 @@ async def test_overlay_process_manager_maps_post_ready_exit_to_runtime_crashed_w
 
     assert manager.state == "failed"
     assert manager.failure_reason == "runtime_crashed"
-    assert manager.restart_scheduled is False
+    assert manager.restart_scheduled is True
     assert manager._manifest_path is None
 
 
@@ -824,6 +822,24 @@ async def test_overlay_process_manager_treats_expected_connected_zero_exit_as_gr
     await manager.stop()
 
     assert manager.state == "off"
+
+
+@pytest.mark.asyncio
+async def test_overlay_process_manager_does_not_restart_when_shutdown_requested() -> None:
+    runner = FakeProcessRunner(ready_event_delay_ms=0)
+    manager = OverlayProcessManager(process_runner=runner)
+
+    await manager.start()
+    assert manager.state == "connected"
+    manager.mark_shutdown_requested()
+    assert runner.last_process is not None
+    runner.last_process._exit_future.set_result(1)
+    assert manager._monitor_task is not None
+    await manager._monitor_task
+
+    assert manager.state == "failed"
+    assert manager.failure_reason == "runtime_crashed"
+    assert manager.restart_scheduled is False
 
 
 @pytest.mark.asyncio

--- a/tests/app/test_runtime_pipeline_composition.py
+++ b/tests/app/test_runtime_pipeline_composition.py
@@ -5,6 +5,10 @@ from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
+from puripuly_heart.app.wiring_local_asr_provider_runtime import (
+    LocalASRProviderRuntimeFactory,
+    ManagedSTTProviderFactory,
+)
 from puripuly_heart.app.wiring_runtime_pipeline import (
     RuntimePipelineLauncher,
     RuntimePipelineResourceOwner,
@@ -163,6 +167,60 @@ async def test_pipeline_composes_each_durable_owner_once_and_injects_same_identi
     assert "llm" not in PeerTranslationChannelOwner.__dataclass_fields__
     assert "stt" not in PeerTranslationChannelOwner.__dataclass_fields__
     assert "peer_stt" not in PeerTranslationChannelOwner.__dataclass_fields__
+
+
+@pytest.mark.asyncio
+async def test_pipeline_binds_stt_event_ingress_observer_to_translation_diagnostics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(runtime_pipeline_module, "create_secret_store", lambda *_a, **_k: object())
+    monkeypatch.setattr(
+        runtime_pipeline_module,
+        "create_translation_backend",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        runtime_pipeline_module,
+        "VrchatOscUdpSender",
+        lambda *_a, **_k: RecordingSender(),
+    )
+    monkeypatch.setattr(
+        runtime_pipeline_module,
+        "ChatboxPaginator",
+        lambda *_a, **_k: RecordingChatbox(),
+    )
+    inner = ManagedSTTProviderFactory(
+        secrets=object(),
+        clock=SystemClock(),
+        reset_deadline_s=1.0,
+        gpu_model_path=Path("gpu.gguf"),
+    )
+    asr_factory = LocalASRProviderRuntimeFactory(
+        provider_factory=inner,
+        provisioning=object(),
+        clock=SystemClock(),
+    )
+
+    pipeline = await compose_runtime_pipeline(
+        settings=AppSettings(),
+        config_path=Path("settings.json"),
+        clock=SystemClock(),
+        runtime_logging=None,
+        managed_release=ManagedRelease(),
+        managed_delegate_ready=lambda: None,
+        local_asr_factory=lambda _secrets: asr_factory,
+        self_capture_factory=lambda *_args: CaptureOwner("self"),
+        peer_capture_factory=lambda *_args: CaptureOwner("peer"),
+        vrc_mic_state=None,
+        vrc_mic_audio_gate=None,
+        receiver_active=False,
+        stt_failure_sink=lambda _message: None,
+    )
+
+    observer = inner.event_ingress_observer
+    assert observer is not None
+    assert observer.__self__ is pipeline.translation_diagnostics
+    assert observer.__func__ is type(pipeline.translation_diagnostics).record_stt_ingress
 
 
 @pytest.mark.asyncio

--- a/tests/app/test_wiring_local_asr_provider_runtime.py
+++ b/tests/app/test_wiring_local_asr_provider_runtime.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 
 import puripuly_heart.app.wiring_local_asr_provider_runtime as runtime_wiring
-from puripuly_heart.app.wiring_local_asr_provider_runtime import ManagedSTTProviderFactory
+from puripuly_heart.app.wiring_local_asr_provider_runtime import (
+    LocalASRProviderRuntimeFactory,
+    ManagedSTTProviderFactory,
+)
 from puripuly_heart.core.local_asr_provider_runtime import ProviderRuntimeBuildRequest
 
 from puripuly_heart.config.resolved import (
@@ -61,11 +64,13 @@ async def test_managed_provider_factory_builds_only_from_immutable_request(
         model_id="nova-3",
         session_options=options,
     )
+    observer = object()
     factory = ManagedSTTProviderFactory(
         secrets=object(),
         clock=FakeClock(),
         reset_deadline_s=300.0,
         gpu_model_path=Path("gpu.gguf"),
+        event_ingress_observer=observer,
     )
     gpu_runtime = object()
 
@@ -83,3 +88,23 @@ async def test_managed_provider_factory_builds_only_from_immutable_request(
     assert provider.channel == "peer"
     assert provider.bridging_ms == 320
     assert provider._pending_session_options == options
+    assert provider.event_ingress_observer is observer
+
+
+def test_local_asr_factory_binds_stt_event_ingress_observer() -> None:
+    inner = ManagedSTTProviderFactory(
+        secrets=object(),
+        clock=FakeClock(),
+        reset_deadline_s=300.0,
+        gpu_model_path=Path("gpu.gguf"),
+    )
+    factory = LocalASRProviderRuntimeFactory(
+        provider_factory=inner,
+        provisioning=object(),
+        clock=FakeClock(),
+    )
+    observer = object()
+
+    factory.bind_stt_event_ingress_observer(observer)
+
+    assert inner.event_ingress_observer is observer

--- a/tests/core/test_chatbox_paginator.py
+++ b/tests/core/test_chatbox_paginator.py
@@ -374,3 +374,49 @@ def test_invalid_limits_raise_value_error() -> None:
 
     with pytest.raises(ValueError, match="page_interval_s"):
         ChatboxPaginator(sender=sender, clock=clock, page_interval_s=0)
+
+
+def test_chatbox_stage_recorder_separates_enqueue_from_udp_page_send() -> None:
+    clock = FakeClock()
+    sender = FakeSender()
+    stages: list[tuple[str, dict[str, object]]] = []
+
+    def record(event: str, **fields: object) -> None:
+        stages.append((event, fields))
+
+    paginator = ChatboxPaginator(
+        sender=sender,
+        clock=clock,
+        max_chars=4,
+        page_interval_s=3.0,
+        stage_recorder=record,
+    )
+    first = _message("abcdefgh", clock)
+    second = _message("ijkl", clock)
+
+    paginator.enqueue(first)
+    paginator.enqueue(second)
+
+    assert [event for event, _fields in stages] == [
+        "message_enqueue",
+        "page_send",
+        "message_enqueue",
+    ]
+    assert stages[0][1]["started"] is True
+    assert stages[1][1]["page_index"] == 0
+    assert stages[1][1]["remaining_parts"] == 1
+    assert stages[2][1]["started"] is False
+    assert stages[2][1]["pending_messages"] == 1
+    assert "text" not in stages[1][1]
+    assert all("abcdefgh" not in str(fields) for _event, fields in stages)
+
+    clock.advance(3.0)
+    paginator.process_due()
+
+    first_pages = [
+        fields
+        for event, fields in stages
+        if event == "page_send" and fields["utterance_id"] == str(first.utterance_id)
+    ]
+    assert [fields["page_index"] for fields in first_pages] == [0, 1]
+    assert first_pages[1]["remaining_parts"] == 0

--- a/tests/core/test_overlay_bridge.py
+++ b/tests/core/test_overlay_bridge.py
@@ -697,6 +697,7 @@ async def test_overlay_bridge_records_disconnect_code_and_reason(
     diagnostics = OverlayDiagnosticsRecorder(
         overlay_instance_id="overlay-test",
         diagnostics_dir=tmp_path,
+        logging_mode="detailed",
     )
     bridge = OverlayBridge(
         session_token="expected-token",
@@ -737,6 +738,7 @@ async def test_overlay_bridge_records_send_failures_and_prunes_stale_connections
     diagnostics = OverlayDiagnosticsRecorder(
         overlay_instance_id="overlay-test",
         diagnostics_dir=tmp_path,
+        logging_mode="detailed",
     )
     bridge = OverlayBridge(
         session_token="expected-token",
@@ -860,7 +862,10 @@ async def test_overlay_bridge_snapshot_broadcast_logs_only_in_detailed_mode(
 
 @pytest.mark.asyncio
 async def test_overlay_bridge_records_snapshot_send_stages_without_payload_text() -> None:
-    recorder = OverlayDiagnosticsRecorder(overlay_instance_id="bridge-stage-test")
+    recorder = OverlayDiagnosticsRecorder(
+        overlay_instance_id="bridge-stage-test",
+        logging_mode="detailed",
+    )
     bridge = OverlayBridge(session_token="expected-token", diagnostics=recorder)
     snapshot = OverlayPresentationSnapshot(
         revision=1,

--- a/tests/core/test_overlay_bridge.py
+++ b/tests/core/test_overlay_bridge.py
@@ -719,7 +719,15 @@ async def test_overlay_bridge_records_disconnect_code_and_reason(
     finally:
         await bridge.stop()
 
-    assert list(diagnostics.bridge_events) == []
+    events = list(diagnostics.bridge_events)
+    assert [event["event"] for event in events] == [
+        "connection_authenticated",
+        "connection_closed",
+        "connection_detached",
+    ]
+    closed = events[1]
+    assert closed["code"] == 4001
+    assert closed["reason"] == "client_bye"
 
 
 @pytest.mark.asyncio
@@ -751,7 +759,15 @@ async def test_overlay_bridge_records_send_failures_and_prunes_stale_connections
         )
     )
 
-    assert list(diagnostics.bridge_events) == []
+    events = list(diagnostics.bridge_events)
+    assert [event["event"] for event in events] == [
+        "send_start",
+        "send_failure",
+        "send_finish",
+    ]
+    assert events[1]["removed"] is True
+    assert events[1]["exception_type"]
+    assert events[2]["stale_connections"] == 1
     assert bridge._authenticated_connections == set()
 
 
@@ -840,3 +856,38 @@ async def test_overlay_bridge_snapshot_broadcast_logs_only_in_detailed_mode(
         and "elapsed_ms=" in message
         for message in broadcast_messages
     )
+
+
+@pytest.mark.asyncio
+async def test_overlay_bridge_records_snapshot_send_stages_without_payload_text() -> None:
+    recorder = OverlayDiagnosticsRecorder(overlay_instance_id="bridge-stage-test")
+    bridge = OverlayBridge(session_token="expected-token", diagnostics=recorder)
+    snapshot = OverlayPresentationSnapshot(
+        revision=1,
+        calibration=OverlayPresentationCalibration(),
+        blocks=[],
+    )
+
+    await bridge.replace_snapshot(snapshot)
+
+    unsent = list(recorder.bridge_events)
+    assert [event["event"] for event in unsent] == ["snapshot_stored_unsent"]
+    assert unsent[0]["revision"] == 1
+
+    connection = _RecordingSendConnection()
+    bridge._authenticated_connections.add(connection)  # type: ignore[arg-type]
+    await bridge.replace_snapshot(
+        OverlayPresentationSnapshot(
+            revision=2,
+            calibration=OverlayPresentationCalibration(),
+            blocks=[],
+        )
+    )
+
+    events = list(recorder.bridge_events)
+    assert [event["event"] for event in events[-2:]] == ["send_start", "send_finish"]
+    assert events[-1]["revision"] == 2
+    assert "elapsed_ms" in events[-1]
+    dumped = json.dumps(events)
+    assert "primary_text" not in dumped
+    assert "secondary_text" not in dumped

--- a/tests/core/test_overlay_diagnostics.py
+++ b/tests/core/test_overlay_diagnostics.py
@@ -200,9 +200,12 @@ def test_overlay_stage_memory_is_recorded_only_in_detailed_mode(tmp_path) -> Non
     assert recorder.record_translation("overlay_emit") == {}
     assert recorder.record_chatbox("page_send") == {}
     assert recorder.record_stt("stt_enqueue") == {}
-    assert recorder.ingest_native_child_line(
-        'presentation_diagnostics [{"stage":"readiness_observed"}]'
-    ) is False
+    assert (
+        recorder.ingest_native_child_line(
+            'presentation_diagnostics [{"stage":"readiness_observed"}]'
+        )
+        is False
+    )
     assert list(recorder.presenter_events) == []
     assert list(recorder.bridge_events) == []
     assert list(recorder.translation_events) == []

--- a/tests/core/test_overlay_diagnostics.py
+++ b/tests/core/test_overlay_diagnostics.py
@@ -105,6 +105,7 @@ def test_overlay_presenter_bridge_translation_events_are_recorded_and_dumped(
     recorder = OverlayDiagnosticsRecorder(
         overlay_instance_id="overlay-stage-trace-test",
         diagnostics_dir=tmp_path,
+        logging_mode="detailed",
     )
 
     presenter_event = recorder.record_presenter(
@@ -152,6 +153,7 @@ def test_overlay_chatbox_stt_and_native_stages_are_dumped_without_payload_text(
     recorder = OverlayDiagnosticsRecorder(
         overlay_instance_id="overlay-gate0-trace-test",
         diagnostics_dir=tmp_path,
+        logging_mode="detailed",
     )
     recorder.record_chatbox(
         "page_send",
@@ -185,3 +187,35 @@ def test_overlay_chatbox_stt_and_native_stages_are_dumped_without_payload_text(
     assert '"actual_visibility": "not_queried"' in raw_dump
     assert "secret chatbox page" not in raw_dump
     assert "secret stt text" not in raw_dump
+
+
+def test_overlay_stage_memory_is_recorded_only_in_detailed_mode(tmp_path) -> None:
+    recorder = OverlayDiagnosticsRecorder(
+        overlay_instance_id="overlay-stage-mode-test",
+        diagnostics_dir=tmp_path,
+    )
+
+    assert recorder.record_presenter("snapshot_publish", revision=1) == {}
+    assert recorder.record_bridge("send_start", revision=1) == {}
+    assert recorder.record_translation("overlay_emit") == {}
+    assert recorder.record_chatbox("page_send") == {}
+    assert recorder.record_stt("stt_enqueue") == {}
+    assert recorder.ingest_native_child_line(
+        'presentation_diagnostics [{"stage":"readiness_observed"}]'
+    ) is False
+    assert list(recorder.presenter_events) == []
+    assert list(recorder.bridge_events) == []
+    assert list(recorder.translation_events) == []
+    assert list(recorder.chatbox_events) == []
+    assert list(recorder.stt_events) == []
+    assert list(recorder.native_events) == []
+
+    recorder.set_logging_mode("detailed")
+    recorder.record_presenter("snapshot_publish", revision=2)
+    recorder.record_process("overlay_trace", trace_event="bounds_confirmed")
+    assert [event["event"] for event in recorder.presenter_events] == ["snapshot_publish"]
+    assert [event["event"] for event in recorder.process_events] == ["overlay_trace"]
+
+    recorder.set_logging_mode("basic")
+    assert list(recorder.presenter_events) == []
+    assert [event["event"] for event in recorder.process_events] == ["overlay_trace"]

--- a/tests/core/test_overlay_diagnostics.py
+++ b/tests/core/test_overlay_diagnostics.py
@@ -97,3 +97,91 @@ def test_overlay_process_trace_is_monotonic_sanitized_and_included_in_failure_du
     raw_dump = recorder.dump_failure(failure_reason="startup_timeout").read_text(encoding="utf-8")
     assert '"trace_event": "bounds_confirmed"' in raw_dump
     assert "private subtitle text" not in raw_dump
+
+
+def test_overlay_presenter_bridge_translation_events_are_recorded_and_dumped(
+    tmp_path,
+) -> None:
+    recorder = OverlayDiagnosticsRecorder(
+        overlay_instance_id="overlay-stage-trace-test",
+        diagnostics_dir=tmp_path,
+    )
+
+    presenter_event = recorder.record_presenter(
+        "snapshot_publish",
+        revision=4,
+        block_count=1,
+        text="private overlay text",
+    )
+    removal_event = recorder.record_presenter_removal(
+        entry_key="self:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    )
+    bridge_event = recorder.record_bridge(
+        "broadcast_finish",
+        revision=4,
+        elapsed_ms=12,
+        transcript="private transcript text",
+    )
+    translation_event = recorder.record_translation(
+        "overlay_emit",
+        event_kind="translation",
+        utterance_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        secondary_len=18,
+    )
+
+    assert presenter_event["category"] == "presenter"
+    assert presenter_event["revision"] == 4
+    assert removal_event["category"] == "presenter_removal"
+    assert bridge_event["category"] == "bridge"
+    assert translation_event["category"] == "translation"
+    assert "private overlay text" not in json.dumps(presenter_event)
+    assert "private transcript text" not in json.dumps(bridge_event)
+
+    raw_dump = recorder.dump_failure(failure_reason="runtime_crashed").read_text(encoding="utf-8")
+    assert '"event": "snapshot_publish"' in raw_dump
+    assert '"event": "entry_removed"' in raw_dump
+    assert '"event": "broadcast_finish"' in raw_dump
+    assert '"event": "overlay_emit"' in raw_dump
+    assert "private overlay text" not in raw_dump
+    assert "private transcript text" not in raw_dump
+
+
+def test_overlay_chatbox_stt_and_native_stages_are_dumped_without_payload_text(
+    tmp_path,
+) -> None:
+    recorder = OverlayDiagnosticsRecorder(
+        overlay_instance_id="overlay-gate0-trace-test",
+        diagnostics_dir=tmp_path,
+    )
+    recorder.record_chatbox(
+        "page_send",
+        utterance_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        page_index=1,
+        pending_messages=1,
+        oldest_age_s=6.0,
+        text="secret chatbox page",
+    )
+    recorder.record_stt(
+        "stt_enqueue",
+        channel="self",
+        queue_depth=2,
+        oldest_age_s=1.5,
+        transcript="secret stt text",
+    )
+    ingested = recorder.ingest_native_child_line(
+        'presentation_diagnostics [{"stage":"readiness_observed","logical_revision":9,'
+        '"outcome":"timed_out","readiness_us":51000,"observed_runtime_visible":true,'
+        '"desired_visible":true,"physical_hmd_visibility":"not_observable"}]'
+    )
+
+    assert ingested is True
+    raw_dump = recorder.dump_failure(failure_reason="runtime_crashed").read_text(encoding="utf-8")
+    assert '"category": "chatbox"' in raw_dump
+    assert '"event": "page_send"' in raw_dump
+    assert '"category": "stt"' in raw_dump
+    assert '"event": "stt_enqueue"' in raw_dump
+    assert '"category": "native"' in raw_dump
+    assert '"event": "readiness_observed"' in raw_dump
+    assert '"actual_visibility": "not_queried"' in raw_dump
+    assert "secret chatbox page" not in raw_dump
+    assert "secret stt text" not in raw_dump

--- a/tests/core/test_overlay_presenter.py
+++ b/tests/core/test_overlay_presenter.py
@@ -7750,3 +7750,45 @@ async def test_native_ownership_transition_serializes_concurrent_target_replacem
     await presenter.update_native_retry_ownership(False)
     assert presenter._peer_presentation_refresh_burst_task is None
     assert presenter._self_presentation_refresh_burst_task is None
+
+
+@pytest.mark.asyncio
+async def test_discard_epoch_retry_intent_drops_old_epoch_generations_and_keeps_captions() -> None:
+    bridge = RecordingPresentationBridge()
+    presenter = OverlayPresenter(
+        bridge=bridge,
+        calibration=OverlayCalibration(),
+        clock=FakeClock(_now=1.0),
+        native_retry_trigger_emission=True,
+        peer_presentation_refresh_burst=False,
+        self_presentation_refresh_burst=False,
+    )
+    adapter = OverlayEventAdapter(clock=FakeClock(_now=1.0))
+    turn_id = uuid4()
+    await presenter.emit(
+        adapter.transcript_final(
+            Transcript(
+                utterance_id=turn_id,
+                channel="self",
+                text="keep this caption",
+                is_final=True,
+                created_at=1.0,
+            ),
+            source_language="en",
+            target_language="ko",
+        )
+    )
+    presenter._native_fresh_render_generations = NativeFreshRenderGenerations(self=4)
+    await presenter._publish_if_changed(force_protocol_publish=True)
+    assert presenter.snapshot().native_fresh_render_generations is not None
+    assert any(block.primary_text == "keep this caption" for block in presenter.snapshot().blocks)
+
+    await presenter.discard_epoch_retry_intent()
+
+    snapshot = presenter.snapshot()
+    assert snapshot.native_fresh_render_generations is None
+    assert snapshot.native_fresh_render_targets is None
+    assert any(block.primary_text == "keep this caption" for block in snapshot.blocks)
+    assert presenter.native_retry_trigger_emission is False
+    assert presenter.peer_presentation_refresh_burst is False
+    assert presenter.self_presentation_refresh_burst is False

--- a/tests/core/test_stt_controller.py
+++ b/tests/core/test_stt_controller.py
@@ -2743,3 +2743,29 @@ async def test_stt_emits_error_event_when_not_closing() -> None:
     while not stt._events.empty():
         events.append(stt._events.get_nowait())
     assert any(isinstance(e, STTErrorEvent) for e in events)
+
+
+async def test_stt_event_ingress_records_enqueue_before_handler_start() -> None:
+    clock = FakeClock()
+    backend = FakeBackend()
+    stages: list[tuple[str, dict[str, object]]] = []
+
+    def observe(event: str, **fields: object) -> None:
+        stages.append((event, fields))
+
+    stt = ManagedSTTProvider(
+        backend=backend,
+        sample_rate_hz=16000,
+        clock=clock,
+        reset_deadline_s=90.0,
+        event_ingress_observer=observe,
+    )
+    await stt._publish_event(STTSessionStateEvent(STTSessionState.STREAMING, channel="self"))
+    assert stages[0][0] == "stt_enqueue"
+    assert stages[0][1]["queue_depth"] == 1
+    stream = stt.events()
+    event = await _next_event(stream)
+    assert isinstance(event, STTSessionStateEvent)
+    assert [name for name, _fields in stages] == ["stt_enqueue", "stt_handler_start"]
+    assert stages[1][1]["queue_depth"] == 0
+    await stt.close()

--- a/tests/core/test_translation_turn_owner.py
+++ b/tests/core/test_translation_turn_owner.py
@@ -72,6 +72,7 @@ def _owner(
     process_child=None,
     output=None,
     trace=None,
+    predecessor_wait_observer=None,
 ) -> TranslationTurnLifecycleOwner:
     events = trace if trace is not None else []
 
@@ -102,6 +103,7 @@ def _owner(
         on_child_terminal=terminal,
         on_parent_closed=closed,
         on_parent_rejected=rejected,
+        predecessor_wait_observer=predecessor_wait_observer,
         output=output,
     )
 
@@ -561,3 +563,37 @@ async def test_terminal_adapter_failure_does_not_strand_parent() -> None:
         await owner.close()
     assert owner.is_parent_closed(parent_id)
     assert owner.has_resources is False
+
+
+@pytest.mark.asyncio
+async def test_same_channel_predecessor_wait_is_observed_without_source_text() -> None:
+    release_first = asyncio.Event()
+    waits: list[tuple[str, dict[str, object]]] = []
+
+    async def process(child, _cancellation_requested):
+        if child.parent_utterance_id == first_id:
+            await release_first.wait()
+        return "translated"
+
+    def observe(event: str, fields) -> None:
+        waits.append((event, dict(fields)))
+
+    first_id = uuid4()
+    second_id = uuid4()
+    owner = _owner(process_child=process, predecessor_wait_observer=observe)
+    try:
+        await owner.submit(_request(parent_id=first_id, turn_kind="self"))
+        await owner.submit(_request(parent_id=second_id, turn_kind="self"))
+        await asyncio.sleep(0)
+        assert [event for event, _fields in waits] == ["predecessor_wait_start"]
+        assert waits[0][1]["parent_utterance_id"] == str(second_id)
+        assert waits[0][1]["predecessor_utterance_id"] == str(first_id)
+        assert "hello" not in str(waits)
+        release_first.set()
+        await owner.wait_for_idle()
+    finally:
+        await owner.close()
+    assert [event for event, _fields in waits] == [
+        "predecessor_wait_start",
+        "predecessor_wait_end",
+    ]

--- a/tests/core/test_translation_turn_owner.py
+++ b/tests/core/test_translation_turn_owner.py
@@ -41,6 +41,32 @@ class RecordingOutput:
             self.trace.append(("output", submission.sequence, submission.outcome))
 
 
+def _translated_result(child: TranslationTurnChild) -> TranslationTurnProcessResult:
+    return TranslationTurnProcessResult(
+        "translated",
+        TranslationOutputSubmission(
+            parent_utterance_id=child.parent_utterance_id,
+            child_utterance_id=child.utterance_id,
+            sequence=child.sequence,
+            channel=child.channel,
+            source=child.source,
+            source_text=child.transcript.text,
+            source_language="en",
+            target_language=child.target_language,
+            outcome="translated",
+            config_snapshot=child.config_snapshot,
+            translation=Translation(
+                utterance_id=child.utterance_id,
+                text="안녕",
+                source_text=child.transcript.text,
+                source_language="en",
+                target_language=child.target_language,
+                channel=child.channel,
+            ),
+        ),
+    )
+
+
 def _request(
     *,
     parent_id: UUID,
@@ -597,3 +623,153 @@ async def test_same_channel_predecessor_wait_is_observed_without_source_text() -
         "predecessor_wait_start",
         "predecessor_wait_end",
     ]
+
+
+@pytest.mark.asyncio
+async def test_blocked_overlay_does_not_delay_next_same_channel_llm() -> None:
+    first_overlay_released = asyncio.Event()
+    events: list[str] = []
+
+    async def process(child: TranslationTurnChild, _cancellation_requested):
+        events.append(f"llm:{child.transcript.text}")
+        return _translated_result(child)
+
+    class BlockingOutput:
+        async def submit_translation_output(
+            self,
+            submission: TranslationOutputSubmission,
+        ) -> None:
+            events.append(f"overlay-start:{submission.source_text}")
+            if submission.source_text == "first":
+                await first_overlay_released.wait()
+            events.append(f"overlay-end:{submission.source_text}")
+
+    owner = _owner(process_child=process, output=BlockingOutput())
+    try:
+        await owner.submit(
+            _request(
+                parent_id=uuid4(),
+                turn_kind="self",
+                runs=(FinalLanguageRun("first", "en"),),
+            )
+        )
+        await owner.submit(
+            _request(
+                parent_id=uuid4(),
+                turn_kind="self",
+                runs=(FinalLanguageRun("second", "en"),),
+            )
+        )
+        for _ in range(50):
+            if "llm:second" in events:
+                break
+            await asyncio.sleep(0)
+        assert events == [
+            "llm:first",
+            "overlay-start:first",
+            "llm:second",
+        ]
+        first_overlay_released.set()
+        await owner.wait_for_idle()
+    finally:
+        await owner.close()
+    assert events == [
+        "llm:first",
+        "overlay-start:first",
+        "llm:second",
+        "overlay-end:first",
+        "overlay-start:second",
+        "overlay-end:second",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_same_channel_output_order_follows_submission_order() -> None:
+    started: list[str] = []
+    output = RecordingOutput()
+
+    async def process(child: TranslationTurnChild, _cancellation_requested):
+        started.append(child.transcript.text)
+        return _translated_result(child)
+
+    owner = _owner(process_child=process, output=output)
+    try:
+        await owner.submit(
+            _request(
+                parent_id=uuid4(),
+                turn_kind="self",
+                runs=(FinalLanguageRun("first", "en"),),
+            )
+        )
+        await owner.submit(
+            _request(
+                parent_id=uuid4(),
+                turn_kind="self",
+                runs=(FinalLanguageRun("second", "en"),),
+            )
+        )
+        await owner.wait_for_idle()
+    finally:
+        await owner.close()
+    assert started == ["first", "second"]
+    assert [submission.source_text for submission in output.submissions] == [
+        "first",
+        "second",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_unexecuted_child_does_not_hold_semantic_gate_on_overlay() -> None:
+    overlay_released = asyncio.Event()
+    events: list[str] = []
+
+    async def created(child: TranslationTurnChild) -> None:
+        events.append(f"created:{child.transcript.text}")
+        if child.transcript.text == "a1":
+            raise RuntimeError("create failed")
+
+    async def process(child: TranslationTurnChild, _cancellation_requested):
+        events.append(f"llm:{child.transcript.text}")
+        return _translated_result(child)
+
+    class BlockingOutput:
+        async def submit_translation_output(
+            self,
+            submission: TranslationOutputSubmission,
+        ) -> None:
+            events.append(f"overlay-start:{submission.source_text}")
+            if submission.source_text == "a2":
+                await overlay_released.wait()
+            events.append(f"overlay-end:{submission.source_text}")
+
+    owner = _owner(process_child=process, output=BlockingOutput())
+    owner.on_child_created = created
+    try:
+        await owner.submit(
+            _request(
+                parent_id=uuid4(),
+                turn_kind="peer",
+                runs=(FinalLanguageRun("a1", "en"), FinalLanguageRun("a2", "ja")),
+            )
+        )
+        await owner.submit(
+            _request(
+                parent_id=uuid4(),
+                turn_kind="peer",
+                runs=(FinalLanguageRun("b", "en"),),
+            )
+        )
+        for _ in range(50):
+            if "llm:b" in events:
+                break
+            await asyncio.sleep(0)
+        assert "llm:a2" in events
+        assert "llm:b" in events
+        assert "overlay-start:a2" in events
+        assert "overlay-end:a2" not in events
+        overlay_released.set()
+        await owner.wait_for_idle()
+    finally:
+        await owner.close()
+    assert "llm:a1" not in events
+    assert events[-2:] == ["overlay-start:b", "overlay-end:b"]

--- a/tests/helpers/translation_owners.py
+++ b/tests/helpers/translation_owners.py
@@ -647,6 +647,7 @@ def compose_translation_test_harness(**values: object) -> TranslationOwnersTestH
         on_child_terminal=callbacks.child_terminal,
         on_parent_closed=callbacks.parent_closed,
         on_parent_rejected=callbacks.parent_rejected,
+        predecessor_wait_observer=translation_diagnostics.record_translation_wait,
         output=callbacks,
         config_snapshot=config_owner.snapshot,
     )


### PR DESCRIPTION
## Summary

Issue #79 Rank 1 preventative hardening only. This is not a claim that long-session overlay/HMD staleness is fixed.

Ship the local repairs we can justify from code contracts, then wait for real-session reports before Rank 2 isolation or P20/HMD work.

### In this PR
- GPU readiness timeout retries instead of killing the overlay process
- OpenVR visibility is reasserted instead of trusting the cache
- Connected-session crashes get a bounded restart; requested shutdown does not
- Same-channel next LLM starts after semantic completion, not after overlay send
- Bounded diagnostic stages exist; stage memory records only in detailed logging, and the jsonl dump still writes on overlay crash

### Not in this PR
- Chatbox stale-pending drop (owner skipped; 3s paging backlog stays)
- Rank 2 overlay transport isolation
- Rank 3 UUID/history hygiene
- P05/P20 or physical-HMD latch changes
- An affected-session timeline; the reporter environment here does not reproduce the stall

## Next
Use this in production. If overlay still dies, stays invisible, or speech/chatbox stalls after hours, collect a detailed-mode session plus any crash dump under `%LOCALAPPDATA%\puripuly-heart\diagnostics\overlay\` and continue from there.

## Test plan
- [x] Focused overlay diagnostics/bridge/translation-turn tests
- [ ] Real SteamVR/VRChat session after merge
- [ ] Watch for duplicate overlay after a crash restart
- [ ] Confirm next translation no longer waits on a slow overlay send