### PR TITLE
Fix OSC control UI synchronization and local Gemma selection

### DIFF
--- a/docs/vrchat-osc.md
+++ b/docs/vrchat-osc.md
@@ -9,7 +9,7 @@
 
 ## Expression Parameters
 
-- Add every required parameter to the avatar's Expression Parameters.
+- Add only the parameters you need to the avatar's Expression Parameters.
 - Match names, capitalization, and types exactly.
 
 | Parameter | Meaning | Type | Default | Saved | Synced |
@@ -97,13 +97,14 @@
 | 7 | Qwen 3.5 Plus |
 | 8 | OpenAI-compatible API |
 | 9 | Custom HTTP API |
-| 10 | Gemma 4 E4B (On-device) |
-| 11 | Gemma 4 12B (On-device) |
+| 10 | Gemma 4 E4B CPU |
+| 11 | Gemma 4 E4B GPU |
+| 12 | Gemma 4 12B |
 
 - Used by: `PuriPuly_Translator`
 - Gemma 4 31B on a Cerebras connection is published as ID `1`; select the connection in PuriPuly.
 - ID `9` selects the currently configured custom HTTP API and does not select an individual extension.
-- IDs `10` and `11` select the on-device models managed by PuriPuly; download them in PuriPuly before use.
+- IDs `10`, `11`, and `12` select the local models managed by PuriPuly; download them in PuriPuly before use.
 
 ### Fallback IDs
 

--- a/src/puripuly_heart/app/ports/osc_control.py
+++ b/src/puripuly_heart/app/ports/osc_control.py
@@ -28,6 +28,8 @@ from puripuly_heart.core.osc.control_schema import (
     OSC_PARAMETER_ADDRESS_PREFIX,
     OSC_PARAMETER_DEFINITIONS,
     OSC_PARAMETER_PREFIX,
+    TRANSLATION_CONNECTION_BY_MODEL_ID,
+    TRANSLATION_MODEL_ID_BY_SELECTION,
     TRANSLATION_MODEL_ID_BY_VALUE,
     TRANSLATION_MODEL_IDS,
     OscParameterDefinition,
@@ -36,6 +38,7 @@ from puripuly_heart.core.osc.control_schema import (
     parameter_definition,
     parameter_definition_for_address,
     registry_for_parameter,
+    translation_model_id_for_selection,
 )
 
 OscConnectionMode = Literal["automatic", "manual", "off"]
@@ -76,7 +79,11 @@ class OscControlApplicationPort(Protocol):
 
     async def set_peer_asr(self, provider: str) -> object: ...
 
-    async def set_translation_model(self, model: str) -> object: ...
+    async def set_translation_model(
+        self,
+        model: str,
+        connection: str | None = None,
+    ) -> object: ...
 
     async def set_fallback(self, alias: str) -> object: ...
 
@@ -110,7 +117,9 @@ __all__ = [
     "OscParameterDefinition",
     "OscParameterType",
     "OscSenderPort",
+    "TRANSLATION_CONNECTION_BY_MODEL_ID",
     "TRANSLATION_MODEL_IDS",
+    "TRANSLATION_MODEL_ID_BY_SELECTION",
     "TRANSLATION_MODEL_ID_BY_VALUE",
     "UnknownOscControlValueError",
     "decode_control_address",
@@ -120,5 +129,6 @@ __all__ = [
     "parameter_definition",
     "parameter_definition_for_address",
     "registry_for_parameter",
+    "translation_model_id_for_selection",
     "validate_control_value",
 ]

--- a/src/puripuly_heart/app/ports/ui_models.py
+++ b/src/puripuly_heart/app/ports/ui_models.py
@@ -49,6 +49,57 @@ class OverlayPeerPresentationState:
     peer_activation_starting: bool
 
 
+OscControlPresentationName = Literal[
+    "PuriPuly_Talk",
+    "PuriPuly_Listen",
+    "PuriPuly_Trans",
+    "PuriPuly_Captions",
+    "PuriPuly_PeerAuto",
+    "PuriPuly_MuteSync",
+    "PuriPuly_ChatboxSource",
+    "PuriPuly_SelfSrcLang",
+    "PuriPuly_SelfDstLang",
+    "PuriPuly_PeerSrcLang",
+    "PuriPuly_PeerDstLang",
+    "PuriPuly_SelfASR",
+    "PuriPuly_PeerASR",
+    "PuriPuly_Translator",
+    "PuriPuly_Fallback",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class OscControlPresentationState:
+    changed_control: OscControlPresentationName
+    self_capture: bool
+    peer_capture: bool
+    translation: bool
+    captions: bool
+    peer_source_mode: str
+    mute_sync: bool
+    chatbox_source: bool
+    self_source_language: str
+    self_target_language: str
+    peer_source_language: str
+    peer_target_language: str
+    self_asr: str
+    peer_asr: str
+    self_asr_setting: str
+    peer_asr_setting: str
+    custom_stt_mode: str
+    custom_stt_compatibility: str
+    llm_provider: str
+    translation_model: str
+    translation_connection: str
+    translation_connection_history: tuple[tuple[str, str], ...]
+    translation_http_extension_id: str | None
+    translation_previous_model: str | None
+    fallback: str
+    fallback_enabled: bool
+    fallback_model: str
+    fallback_connection: str
+
+
 __all__ = [
     "GpuDashboardNotice",
     "GpuDeviceOption",
@@ -56,5 +107,7 @@ __all__ = [
     "ManagedGemmaDashboardNotice",
     "ManagedGemmaNoticeAction",
     "OptionItem",
+    "OscControlPresentationName",
+    "OscControlPresentationState",
     "OverlayPeerPresentationState",
 ]

--- a/src/puripuly_heart/app/ports/ui_presentation.py
+++ b/src/puripuly_heart/app/ports/ui_presentation.py
@@ -5,6 +5,7 @@ from typing import Any, Protocol
 
 from puripuly_heart.app.ports.ui_models import (
     ManagedGemmaDashboardNotice,
+    OscControlPresentationState,
     OverlayPeerPresentationState,
 )
 from puripuly_heart.core.runtime.output import UIEventBridgePort
@@ -96,6 +97,8 @@ class UiPresentationPort(Protocol):
         recent_target_languages: list[str],
         peer_auto_detect_available: bool,
     ) -> None: ...
+
+    def project_osc_control_state(self, state: OscControlPresentationState) -> None: ...
 
     def render_settings(
         self,

--- a/src/puripuly_heart/app/services/osc/control_application.py
+++ b/src/puripuly_heart/app/services/osc/control_application.py
@@ -123,12 +123,23 @@ class SettingsBackedOscControlApplication(OscControlApplicationPort):
             )
         )
 
-    async def set_translation_model(self, model: str) -> object:
+    async def set_translation_model(
+        self,
+        model: str,
+        connection: str | None = None,
+    ) -> object:
         current = self.settings_provider()
-        if current is not None and _osc_translation_model_value(current.translation.model) == model:
+        if (
+            current is not None
+            and _osc_translation_model_value(current.translation.model) == model
+            and (
+                connection is None
+                or _enum_value_for_compare(current.translation.connection) == connection
+            )
+        ):
             return True
         return await self._apply_settings(
-            lambda settings: self._set_translation_model(settings, model)
+            lambda settings: self._set_translation_model(settings, model, connection)
         )
 
     async def set_fallback(self, alias: str) -> object:
@@ -200,12 +211,22 @@ class SettingsBackedOscControlApplication(OscControlApplicationPort):
         settings.languages.peer_source_language = peer_source
         settings.languages.peer_target_language = peer_target
 
-    def _set_translation_model(self, settings: object, model: str) -> None:
+    def _set_translation_model(
+        self,
+        settings: object,
+        model: str,
+        connection: str | None,
+    ) -> None:
         current_model = settings.translation.model
         current_value = getattr(current_model, "value", current_model)
         if model == "custom_http" and current_value != "custom_http":
             settings.translation.previous_llm_model = current_model
         settings.translation.model = _enum_value(settings.translation.model, model)
+        if connection is not None:
+            settings.translation.connection = _enum_value(
+                settings.translation.connection,
+                connection,
+            )
         self.translation_model_normalizer(settings)
 
     @staticmethod

--- a/src/puripuly_heart/app/services/osc/control_application.py
+++ b/src/puripuly_heart/app/services/osc/control_application.py
@@ -17,6 +17,12 @@ ApplicationCall = Callable[..., Awaitable[object]]
 TranslationModelNormalizer = Callable[[object], object]
 
 
+@dataclass(frozen=True, slots=True)
+class OscControlApplyResult:
+    applied: bool
+    canonical_state_changed: bool
+
+
 @dataclass(slots=True)
 class SettingsBackedOscControlApplication(OscControlApplicationPort):
     settings_provider: SettingsProvider
@@ -166,10 +172,17 @@ class SettingsBackedOscControlApplication(OscControlApplicationPort):
         current = self.settings_provider()
         if current is None:
             raise RuntimeError("OSC control settings are unavailable")
+        previous = copy.deepcopy(current)
         updated = copy.deepcopy(current)
         mutator(updated)
         result = await self.apply_settings(updated)
-        if not _settings_control_values_match(self.settings_provider(), updated):
+        actual = self.settings_provider()
+        if not _settings_control_values_match(actual, updated):
+            if not _settings_control_values_match(actual, previous):
+                return OscControlApplyResult(
+                    applied=False,
+                    canonical_state_changed=True,
+                )
             return False
         return result
 
@@ -324,4 +337,4 @@ def _enum_value_for_compare(value: object) -> object:
     return getattr(value, "value", value)
 
 
-__all__ = ["SettingsBackedOscControlApplication"]
+__all__ = ["OscControlApplyResult", "SettingsBackedOscControlApplication"]

--- a/src/puripuly_heart/app/services/osc/control_router.py
+++ b/src/puripuly_heart/app/services/osc/control_router.py
@@ -11,6 +11,7 @@ from puripuly_heart.app.ports.osc_control import (
     ASR_IDS,
     FALLBACK_IDS,
     LANGUAGE_IDS,
+    TRANSLATION_CONNECTION_BY_MODEL_ID,
     TRANSLATION_MODEL_IDS,
     OscControlApplicationPort,
     OscControlCodecError,
@@ -329,7 +330,11 @@ class OscControlRouter:
         if message.name == "PuriPuly_PeerASR":
             return await app.set_peer_asr(ASR_IDS[message.value])  # type: ignore[index]
         if message.name == "PuriPuly_Translator":
-            return await app.set_translation_model(TRANSLATION_MODEL_IDS[message.value])  # type: ignore[index]
+            value = int(message.value)
+            return await app.set_translation_model(
+                TRANSLATION_MODEL_IDS[value],
+                TRANSLATION_CONNECTION_BY_MODEL_ID.get(value),
+            )
         if message.name == "PuriPuly_Fallback":
             return await app.set_fallback(FALLBACK_IDS[message.value])  # type: ignore[index]
         raise RuntimeError(f"unhandled PuriPuly OSC parameter: {message.name}")

--- a/src/puripuly_heart/app/services/osc/control_router.py
+++ b/src/puripuly_heart/app/services/osc/control_router.py
@@ -5,7 +5,7 @@ import contextlib
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 from puripuly_heart.app.ports.osc_control import (
     ASR_IDS,
@@ -17,6 +17,7 @@ from puripuly_heart.app.ports.osc_control import (
     OscControlMessage,
     decode_control_message,
 )
+from puripuly_heart.app.ports.ui_models import OscControlPresentationName
 from puripuly_heart.core.lifecycle import LifecycleScope, start_lifecycle_task
 
 logger = logging.getLogger(__name__)
@@ -60,6 +61,7 @@ class OscControlRouter:
         echo_suppression_provider: Callable[[OscControlMessage], bool] | None = None,
         canonical_state_republisher: Callable[[], object] | None = None,
         canonical_state_full_republisher: Callable[[], object] | None = None,
+        canonical_state_projector: Callable[[OscControlPresentationName], object] | None = None,
         error_sink: Callable[[str], None] | None = None,
     ) -> None:
         self._application = application
@@ -68,6 +70,7 @@ class OscControlRouter:
         self._echo_suppression_provider = echo_suppression_provider
         self._canonical_state_republisher = canonical_state_republisher
         self._canonical_state_full_republisher = canonical_state_full_republisher
+        self._canonical_state_projector = canonical_state_projector
         self._language_values = (
             language_state_provider()
             if language_state_provider is not None
@@ -203,9 +206,13 @@ class OscControlRouter:
                         key=lambda item: item[1].sequence,
                     )
                     del self._pending[name]
+                if current.future.cancelled():
+                    current = None
+                    continue
                 result = await self._apply_serialized(
                     current.message,
                     generation=current.generation,
+                    cancelled=current.future.cancelled,
                 )
                 if not current.future.done():
                     current.future.set_result(result)
@@ -222,13 +229,19 @@ class OscControlRouter:
         message: OscControlMessage,
         *,
         generation: int,
+        cancelled: Callable[[], bool] | None = None,
     ) -> OscDispatchResult:
         if not self._is_generation_current(generation):
             return OscDispatchResult(False, message.name, error=self._generation_error())
+        if cancelled is not None and cancelled():
+            return OscDispatchResult(False, message.name, error="cancelled")
+        invocation_task: asyncio.Task[Any] | None = None
         try:
             async with self._serial_lock:
                 if not self._is_generation_current(generation):
                     return OscDispatchResult(False, message.name, error=self._generation_error())
+                if cancelled is not None and cancelled():
+                    return OscDispatchResult(False, message.name, error="cancelled")
                 invocation_task = asyncio.current_task()
                 if invocation_task is not None:
                     self._active_invocation_tasks.add(invocation_task)
@@ -241,11 +254,32 @@ class OscControlRouter:
             self._republish_canonical_state()
             self._report_error(f"{message.name}: {type(exc).__name__}")
             return OscDispatchResult(False, message.name, error=type(exc).__name__)
+        if self._closed:
+            return OscDispatchResult(False, message.name, error="router_closed")
+        if (cancelled is not None and cancelled()) or (
+            invocation_task is not None and invocation_task.cancelling()
+        ):
+            return OscDispatchResult(False, message.name, error="cancelled")
+        if not self._is_generation_current(generation):
+            return OscDispatchResult(False, message.name, error=self._generation_error())
         if _application_result_rejected(result):
             self._republish_canonical_state()
+            if (
+                _application_result_changed_canonical_state(result)
+                and self._is_generation_current(generation)
+                and not (cancelled is not None and cancelled())
+            ):
+                self._project_canonical_state(cast(OscControlPresentationName, message.name))
             self._report_error(f"{message.name}: application_rejected")
             return OscDispatchResult(False, message.name, error="application_rejected")
         self._publish_canonical_delta()
+        if (cancelled is not None and cancelled()) or (
+            invocation_task is not None and invocation_task.cancelling()
+        ):
+            return OscDispatchResult(False, message.name, error="cancelled")
+        if not self._is_generation_current(generation):
+            return OscDispatchResult(False, message.name, error=self._generation_error())
+        self._project_canonical_state(cast(OscControlPresentationName, message.name))
         return OscDispatchResult(True, message.name, error=None if result is None else None)
 
     async def _invoke(self, message: OscControlMessage) -> object:
@@ -326,6 +360,13 @@ class OscControlRouter:
         with contextlib.suppress(Exception):
             callback()
 
+    def _project_canonical_state(self, control: OscControlPresentationName) -> None:
+        callback = self._canonical_state_projector
+        if callback is None:
+            return
+        with contextlib.suppress(Exception):
+            callback(control)
+
     def _is_generation_current(self, generation: int) -> bool:
         return not self._closed and self._ingress_enabled and generation == self._generation
 
@@ -373,6 +414,10 @@ def _application_result_rejected(result: object) -> bool:
     if not isinstance(status, str):
         return False
     return "degraded" in status or "failed" in status
+
+
+def _application_result_changed_canonical_state(result: object) -> bool:
+    return getattr(result, "canonical_state_changed", False) is True
 
 
 __all__ = ["OscControlRouter", "OscDispatchResult"]

--- a/src/puripuly_heart/app/services/osc/control_runtime.py
+++ b/src/puripuly_heart/app/services/osc/control_runtime.py
@@ -13,6 +13,10 @@ from puripuly_heart.app.ports.osc_control import (
     decode_control_message,
 )
 from puripuly_heart.app.ports.oscquery import OscQueryServicePort
+from puripuly_heart.app.ports.ui_models import (
+    OscControlPresentationName,
+    OscControlPresentationState,
+)
 from puripuly_heart.app.services.vrc_mic_sync import VrcMicSyncOwner
 from puripuly_heart.core.lifecycle import LifecycleScope, start_lifecycle_task
 from puripuly_heart.core.runtime.oscquery import (
@@ -38,6 +42,10 @@ class OscControlIntegrationOwner:
         state_provider: Callable[[], OscCanonicalState],
         language_state_provider: Callable[[], tuple[str, str, str, str]],
         translation_model_normalizer: Callable[[object], object],
+        ui_state_provider: (
+            Callable[[OscControlPresentationName], OscControlPresentationState] | None
+        ) = None,
+        ui_state_sink: Callable[[OscControlPresentationState], None] | None = None,
         query_service: OscQueryServicePort | None = None,
         error_sink: Callable[[str], None] | None = None,
         resync_timeout_seconds: float = 1.5,
@@ -47,6 +55,8 @@ class OscControlIntegrationOwner:
         self._application_provider = application_provider
         self._sender_provider = sender_provider
         self._state_provider = state_provider
+        self._ui_state_provider = ui_state_provider
+        self._ui_state_sink = ui_state_sink
         self._error_sink = error_sink
         self._mode: OscConnectionMode = "off"
         self._send_port = 9000
@@ -83,6 +93,7 @@ class OscControlIntegrationOwner:
             echo_suppression_provider=self._is_echo,
             canonical_state_republisher=self._publish_delta,
             canonical_state_full_republisher=self._publish_full,
+            canonical_state_projector=self._project_ui_state,
             error_sink=error_sink,
         )
         self._receiver_owner.set_packet_handlers(
@@ -330,6 +341,11 @@ class OscControlIntegrationOwner:
         if inspect.isawaitable(result):
             return await result
         return result
+
+    def _project_ui_state(self, control: OscControlPresentationName) -> None:
+        if self._ui_state_provider is None or self._ui_state_sink is None:
+            return
+        self._ui_state_sink(self._ui_state_provider(control))
 
     def _dashboard_command_matches_canonical_state(self, method_name: str, value: bool) -> bool:
         field_by_method = {

--- a/src/puripuly_heart/app/services/osc/presentation_state.py
+++ b/src/puripuly_heart/app/services/osc/presentation_state.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import Any
+
+from puripuly_heart.app.ports.ui_models import (
+    OscControlPresentationName,
+    OscControlPresentationState,
+)
+from puripuly_heart.app.services.osc.state_publisher import OscCanonicalState
+
+
+def presentation_state_from_settings(
+    settings: Any,
+    *,
+    canonical_state: OscCanonicalState,
+    changed_control: OscControlPresentationName,
+    self_capture_effective: bool | None = None,
+) -> OscControlPresentationState:
+    translation = settings.translation
+    fallback = translation.fallback
+    return OscControlPresentationState(
+        changed_control=changed_control,
+        self_capture=(
+            canonical_state.self_capture
+            if self_capture_effective is None
+            else bool(self_capture_effective)
+        ),
+        peer_capture=canonical_state.peer_capture,
+        translation=canonical_state.translation,
+        captions=canonical_state.captions,
+        peer_source_mode=settings.languages.peer_source_mode,
+        mute_sync=canonical_state.mute_sync,
+        chatbox_source=canonical_state.chatbox_source,
+        self_source_language=canonical_state.self_source_language,
+        self_target_language=canonical_state.self_target_language,
+        peer_source_language=canonical_state.peer_source_language,
+        peer_target_language=canonical_state.peer_target_language,
+        self_asr=canonical_state.self_asr,
+        peer_asr=canonical_state.peer_asr,
+        self_asr_setting=str(getattr(settings.provider.stt, "value", settings.provider.stt)),
+        peer_asr_setting=str(
+            getattr(settings.provider.peer_stt, "value", settings.provider.peer_stt)
+        ),
+        custom_stt_mode=str(settings.custom_stt.mode),
+        custom_stt_compatibility=str(settings.custom_stt.compatibility),
+        llm_provider=str(getattr(settings.provider.llm, "value", settings.provider.llm)),
+        translation_model=str(getattr(translation.model, "value", translation.model)),
+        translation_connection=str(
+            getattr(translation.connection, "value", translation.connection)
+        ),
+        translation_connection_history=tuple(
+            sorted(
+                (
+                    str(getattr(model, "value", model)),
+                    str(getattr(connection, "value", connection)),
+                )
+                for model, connection in translation.connection_history.items()
+            )
+        ),
+        translation_http_extension_id=translation.http_extension_id,
+        translation_previous_model=(
+            None
+            if translation.previous_llm_model is None
+            else str(
+                getattr(
+                    translation.previous_llm_model,
+                    "value",
+                    translation.previous_llm_model,
+                )
+            )
+        ),
+        fallback=canonical_state.fallback,
+        fallback_enabled=bool(fallback.enabled),
+        fallback_model=str(getattr(fallback.model, "value", fallback.model)),
+        fallback_connection=str(getattr(fallback.connection, "value", fallback.connection)),
+    )
+
+
+__all__ = ["presentation_state_from_settings"]

--- a/src/puripuly_heart/app/services/osc/state_publisher.py
+++ b/src/puripuly_heart/app/services/osc/state_publisher.py
@@ -10,9 +10,9 @@ from puripuly_heart.app.ports.osc_control import (
     FALLBACK_ID_BY_ALIAS,
     LANGUAGE_ID_BY_CODE,
     OSC_PARAMETER_ADDRESS_PREFIX,
-    TRANSLATION_MODEL_ID_BY_VALUE,
     OscControlCodecError,
     OscSenderPort,
+    translation_model_id_for_selection,
     validate_control_value,
 )
 
@@ -33,6 +33,7 @@ class OscCanonicalState:
     self_asr: str = "local_cpu_auto"
     peer_asr: str = "local_cpu_auto"
     translation_model: str = "gemma4_26b_31b"
+    translation_connection: str = "managed"
     fallback: str = "none"
 
 
@@ -155,9 +156,10 @@ class OscStatePublisher:
                 "PuriPuly_PeerDstLang": LANGUAGE_ID_BY_CODE[fields_by_name["peer_target_language"]],
                 "PuriPuly_SelfASR": ASR_ID_BY_PROVIDER[fields_by_name["self_asr"]],
                 "PuriPuly_PeerASR": ASR_ID_BY_PROVIDER[fields_by_name["peer_asr"]],
-                "PuriPuly_Translator": TRANSLATION_MODEL_ID_BY_VALUE[
-                    fields_by_name["translation_model"]
-                ],
+                "PuriPuly_Translator": translation_model_id_for_selection(
+                    fields_by_name["translation_model"],
+                    fields_by_name["translation_connection"],
+                ),
                 "PuriPuly_Fallback": FALLBACK_ID_BY_ALIAS[fields_by_name["fallback"]],
             }
         )
@@ -188,6 +190,7 @@ def state_from_settings(
         self_asr=_osc_asr_provider(settings.provider.stt, settings.custom_stt.mode),
         peer_asr=_osc_asr_provider(settings.provider.peer_stt, settings.custom_stt.mode),
         translation_model=settings.translation.model.value,
+        translation_connection=settings.translation.connection.value,
         fallback=fallback_alias_from_settings(settings),
     )
 

--- a/src/puripuly_heart/app/services/settings/settings_application.py
+++ b/src/puripuly_heart/app/services/settings/settings_application.py
@@ -96,7 +96,12 @@ class SettingsApplicationOwner:
     failure_sink: SettingsFailureSink
     results: SettingsTransactionResultOwner = field(default_factory=SettingsTransactionResultOwner)
 
-    async def apply(self, next_settings: AppSettings) -> bool:
+    async def apply(
+        self,
+        next_settings: AppSettings,
+        *,
+        reload_settings_view: bool = True,
+    ) -> bool:
         current = self.settings.current
         if current is not None:
             self.settings.normalize_compatibility(current)
@@ -152,17 +157,34 @@ class SettingsApplicationOwner:
                 )
             installation_fallback = bool(fallback_plan.installation_fallback and fallback_channels)
         if next_settings is not self.settings.current:
-            if await self._route(next_settings):
+            if await self._route(
+                next_settings,
+                reload_settings_view=reload_settings_view,
+            ):
                 self.fallback_sink(fallback_channels, installation_fallback)
                 return True
-        await self.apply_direct(next_settings)
+        await self.apply_direct(
+            next_settings,
+            reload_settings_view=reload_settings_view,
+        )
         self.fallback_sink(fallback_channels, installation_fallback)
         return True
 
-    async def _route(self, next_settings: AppSettings) -> bool:
-        if await self._apply_combined(next_settings):
+    async def _route(
+        self,
+        next_settings: AppSettings,
+        *,
+        reload_settings_view: bool,
+    ) -> bool:
+        if await self._apply_combined(
+            next_settings,
+            reload_settings_view=reload_settings_view,
+        ):
             return True
-        if await self._apply_stt_language_audio(next_settings):
+        if await self._apply_stt_language_audio(
+            next_settings,
+            reload_settings_view=reload_settings_view,
+        ):
             return True
         if await self._apply_overlay_osc_output(next_settings):
             return True
@@ -309,6 +331,7 @@ class SettingsApplicationOwner:
         *,
         base_settings: AppSettings,
         committed_settings: AppSettings,
+        reload_settings_view: bool = True,
     ) -> None:
         self.settings.begin(legacy_snapshot=committed_settings)
         committed = False
@@ -329,14 +352,21 @@ class SettingsApplicationOwner:
             copy.deepcopy(base_settings),
             persist=False,
             strict_runtime_errors=False,
+            reload_settings_view=reload_settings_view,
         )
         self.settings.current = copy.deepcopy(base_settings)
-        self.projection.render(
-            self.settings.current,
-            preserve_custom_vocab_draft=True,
-        )
+        if reload_settings_view:
+            self.projection.render(
+                self.settings.current,
+                preserve_custom_vocab_draft=True,
+            )
 
-    async def _apply_combined(self, next_settings: AppSettings) -> bool:
+    async def _apply_combined(
+        self,
+        next_settings: AppSettings,
+        *,
+        reload_settings_view: bool,
+    ) -> bool:
         order22 = self.projection.order22_patch_base_and_values(next_settings)
         order23 = self.projection.order23_patch_base_and_values(next_settings)
         order24 = self.projection.order24_patch_base_and_values(next_settings)
@@ -405,6 +435,7 @@ class SettingsApplicationOwner:
                     next_settings,
                     strict_runtime_errors=True,
                     strict_persistence_errors=True,
+                    reload_settings_view=reload_settings_view,
                 )
             except StrictSettingsSaveFailed:
                 if committed_before_full_draft is not None:
@@ -421,7 +452,7 @@ class SettingsApplicationOwner:
             except Exception:
                 self._set_result(_ui_prompt_clipboard_state_runtime_degraded_transaction_result())
 
-        if self.settings.current is not None:
+        if reload_settings_view and self.settings.current is not None:
             self.projection.render(
                 self.settings.current,
                 preserve_custom_vocab_draft=True,
@@ -493,6 +524,7 @@ class SettingsApplicationOwner:
                 await self.compensate_failed_local_asr_settings_apply(
                     base_settings=base_settings,
                     committed_settings=committed_settings,
+                    reload_settings_view=reload_settings_view,
                 )
             except Exception:
                 self.failure_sink("Failed to compensate local ASR settings apply")

--- a/src/puripuly_heart/app/wiring/wiring_vrc_mic_sync.py
+++ b/src/puripuly_heart/app/wiring/wiring_vrc_mic_sync.py
@@ -4,6 +4,10 @@ import logging
 from collections.abc import Awaitable, Callable, Mapping
 
 from puripuly_heart.app.ports.oscquery import OscQueryServicePort
+from puripuly_heart.app.ports.ui_models import (
+    OscControlPresentationName,
+    OscControlPresentationState,
+)
 from puripuly_heart.app.services.osc.control_runtime import OscControlIntegrationOwner
 from puripuly_heart.app.services.osc.state_publisher import OscCanonicalState
 from puripuly_heart.app.services.vrc_mic_sync import (
@@ -29,6 +33,8 @@ def compose_vrc_mic_sync(
     application_provider: Callable[[], object | None],
     sender_provider: Callable[[], object | None],
     osc_state_provider: Callable[[], OscCanonicalState],
+    ui_state_provider: Callable[[OscControlPresentationName], OscControlPresentationState],
+    ui_state_sink: Callable[[OscControlPresentationState], None],
     language_state_provider: Callable[[], tuple[str, str, str, str]],
     translation_model_normalizer: Callable[[object], object],
     query_service: OscQueryServicePort | None = None,
@@ -55,6 +61,8 @@ def compose_vrc_mic_sync(
         application_provider=application_provider,
         sender_provider=sender_provider,
         state_provider=osc_state_provider,
+        ui_state_provider=ui_state_provider,
+        ui_state_sink=ui_state_sink,
         language_state_provider=language_state_provider,
         translation_model_normalizer=translation_model_normalizer,
         query_service=query_service or ZeroconfOscQueryService(),

--- a/src/puripuly_heart/composition/application_runtime.py
+++ b/src/puripuly_heart/composition/application_runtime.py
@@ -37,7 +37,11 @@ from puripuly_heart.app.ports.runtime_pipeline_lifecycle import (
     RuntimePipelineStartCallbacks,
 )
 from puripuly_heart.app.ports.ui_application import UiApplicationPort
-from puripuly_heart.app.ports.ui_models import ManagedGemmaDashboardNotice
+from puripuly_heart.app.ports.ui_models import (
+    ManagedGemmaDashboardNotice,
+    OscControlPresentationName,
+    OscControlPresentationState,
+)
 from puripuly_heart.app.ports.ui_presentation import UIEventBridgePort, UiPresentationPort
 from puripuly_heart.app.ports.vrchat_osc_presence import VrchatOscPresencePort
 from puripuly_heart.app.services.application_after_launch import (
@@ -92,6 +96,9 @@ from puripuly_heart.app.services.manual_local_asr_fallback import (
 )
 from puripuly_heart.app.services.manual_typing import ManualTypingOwner
 from puripuly_heart.app.services.osc.control_runtime import OscControlIntegrationOwner
+from puripuly_heart.app.services.osc.presentation_state import (
+    presentation_state_from_settings,
+)
 from puripuly_heart.app.services.osc.state_publisher import state_from_settings
 from puripuly_heart.app.services.overlay_application import (
     OverlayApplicationOwner,
@@ -983,6 +990,22 @@ def compose_application_runtime(
                     value.languages.peer_target_language,
                 )
 
+            def osc_ui_state(
+                control: OscControlPresentationName,
+            ) -> OscControlPresentationState:
+                value = current_settings()
+                if value is None:
+                    value = AppSettings()
+                return presentation_state_from_settings(
+                    value,
+                    canonical_state=osc_state(),
+                    changed_control=control,
+                    self_capture_effective=bool(
+                        pipeline.self_capture is not None
+                        and pipeline.self_capture.snapshot.effective_active
+                    ),
+                )
+
             vrc_mic_sync = compose_vrc_mic_sync(
                 state_provider=lambda: pipeline.vrc_mic_state,
                 gate_provider=lambda: pipeline.vrc_mic_audio_gate,
@@ -993,11 +1016,14 @@ def compose_application_runtime(
                 error_sink=log_error,
                 settings_provider=current_settings,
                 apply_settings=lambda next_settings: require_settings_application().apply(
-                    next_settings
+                    next_settings,
+                    reload_settings_view=False,
                 ),
                 application_provider=lambda: application,
                 sender_provider=lambda: pipeline.sender,
                 osc_state_provider=osc_state,
+                ui_state_provider=osc_ui_state,
+                ui_state_sink=presentation.project_osc_control_state,
                 language_state_provider=language_state,
                 translation_model_normalizer=materialize_translation_settings,
             )

--- a/src/puripuly_heart/core/osc/control_schema.py
+++ b/src/puripuly_heart/core/osc/control_schema.py
@@ -46,7 +46,7 @@ INTEGER_CONTROLS: Final[Mapping[str, str]] = MappingProxyType(
         "PuriPuly_PeerDstLang": "languages.peer_target_language",
         "PuriPuly_SelfASR": "stt.provider",
         "PuriPuly_PeerASR": "peer_stt.provider",
-        "PuriPuly_Translator": "translation.model",
+        "PuriPuly_Translator": "translation.selection",
         "PuriPuly_Fallback": "translation.fallback",
     }
 )
@@ -94,7 +94,16 @@ TRANSLATION_MODEL_IDS: Final[Mapping[int, str]] = MappingProxyType(
         8: "local_llm",
         9: "custom_http",
         10: "managed_gemma",
-        11: "managed_gemma_12b",
+        11: "managed_gemma",
+        12: "managed_gemma_12b",
+    }
+)
+
+TRANSLATION_CONNECTION_BY_MODEL_ID: Final[Mapping[int, str]] = MappingProxyType(
+    {
+        10: "cpu",
+        11: "gpu",
+        12: "gpu",
     }
 )
 
@@ -163,7 +172,16 @@ ASR_ID_BY_PROVIDER: Final[Mapping[str, int]] = MappingProxyType(
 TRANSLATION_MODEL_ID_BY_VALUE: Final[Mapping[str, int]] = MappingProxyType(
     {
         **{value: identifier for identifier, value in TRANSLATION_MODEL_IDS.items()},
+        "managed_gemma": 10,
+        "managed_gemma_12b": 12,
         "gemma4_31b_cerebras": 1,
+    }
+)
+TRANSLATION_MODEL_ID_BY_SELECTION: Final[Mapping[tuple[str, str], int]] = MappingProxyType(
+    {
+        ("managed_gemma", "cpu"): 10,
+        ("managed_gemma", "gpu"): 11,
+        ("managed_gemma_12b", "gpu"): 12,
     }
 )
 FALLBACK_ID_BY_ALIAS: Final[Mapping[str, int]] = MappingProxyType(
@@ -203,6 +221,12 @@ def registry_for_parameter(name: str) -> Mapping[int, str] | None:
     return OSC_INTEGER_REGISTRIES.get(name)
 
 
+def translation_model_id_for_selection(model: str, connection: str) -> int:
+    if model in {"managed_gemma", "managed_gemma_12b"}:
+        return TRANSLATION_MODEL_ID_BY_SELECTION[(model, connection)]
+    return TRANSLATION_MODEL_ID_BY_VALUE[model]
+
+
 def is_puripuly_parameter_address(address: str) -> bool:
     return (
         isinstance(address, str)
@@ -231,9 +255,12 @@ __all__ = [
     "OscParameterDefinition",
     "OscParameterType",
     "TRANSLATION_MODEL_IDS",
+    "TRANSLATION_CONNECTION_BY_MODEL_ID",
     "TRANSLATION_MODEL_ID_BY_VALUE",
+    "TRANSLATION_MODEL_ID_BY_SELECTION",
     "is_puripuly_parameter_address",
     "parameter_definition",
     "parameter_definition_for_address",
     "registry_for_parameter",
+    "translation_model_id_for_selection",
 ]

--- a/src/puripuly_heart/ui/presentation_adapter.py
+++ b/src/puripuly_heart/ui/presentation_adapter.py
@@ -9,6 +9,7 @@ import flet as ft
 
 from puripuly_heart.app.ports.ui_models import (
     ManagedGemmaDashboardNotice,
+    OscControlPresentationState,
     OverlayPeerPresentationState,
 )
 from puripuly_heart.app.ports.ui_presentation import UIEventBridgePort, UiPresentationPort
@@ -298,6 +299,16 @@ class FletUiPresentationAdapter:
         set_peer_auto = getattr(dashboard, "set_peer_auto_detect_available", None)
         if callable(set_peer_auto):
             set_peer_auto(peer_auto_detect_available)
+
+    def project_osc_control_state(self, state: OscControlPresentationState) -> None:
+        dashboard = getattr(self._app, "view_dashboard", None)
+        project_dashboard = getattr(dashboard, "project_osc_control_state", None)
+        if callable(project_dashboard):
+            project_dashboard(state)
+        settings = getattr(self._app, "view_settings", None)
+        project_settings = getattr(settings, "project_osc_control_state", None)
+        if callable(project_settings):
+            project_settings(state)
 
     def render_settings(
         self,

--- a/src/puripuly_heart/ui/views/dashboard.py
+++ b/src/puripuly_heart/ui/views/dashboard.py
@@ -7,6 +7,7 @@ from puripuly_heart.app.language_selection import LanguageSelectionChange
 from puripuly_heart.app.ports.ui_models import (
     ManagedGemmaDashboardNotice,
     ManagedGemmaNoticeAction,
+    OscControlPresentationState,
 )
 from puripuly_heart.core.language import get_all_language_options
 from puripuly_heart.ui.components.display_card import DisplayCard
@@ -526,6 +527,50 @@ class DashboardView(ft.Column):
         self._peer_source_mode = peer_source_mode
         self._update_input_font()
         self._refresh_language_card()
+
+    def project_osc_control_state(self, state: OscControlPresentationState) -> None:
+        control = state.changed_control
+        if control == "PuriPuly_Talk":
+            if self._stt_is_starting:
+                self._sync_stt_button_state()
+            else:
+                self.set_stt_enabled(state.self_capture)
+        elif control == "PuriPuly_Trans":
+            self.set_translation_enabled(state.translation)
+        elif control in {
+            "PuriPuly_PeerAuto",
+            "PuriPuly_SelfSrcLang",
+            "PuriPuly_SelfDstLang",
+            "PuriPuly_PeerSrcLang",
+            "PuriPuly_PeerDstLang",
+        }:
+            self.set_languages_from_codes(
+                state.self_source_language,
+                state.self_target_language,
+                state.peer_source_language,
+                state.peer_target_language,
+                state.peer_source_mode,
+            )
+        elif control == "PuriPuly_PeerASR":
+            self.set_peer_auto_detect_available(state.peer_asr in {"soniox", "local_qwen_gpu"})
+        elif control in {"PuriPuly_Listen", "PuriPuly_Captions"}:
+            capture = capture_presentation_from_contract(self._overlay_peer_contract)
+            if control == "PuriPuly_Listen":
+                if capture.peer.starting or capture.peer.warning:
+                    self._capture_controls.apply_peer_capture_state(
+                        enabled=capture.peer.enabled,
+                        starting=capture.peer.starting,
+                        warning=capture.peer.warning,
+                    )
+                else:
+                    self._capture_controls.apply_peer_capture_state(enabled=state.peer_capture)
+            elif capture.overlay.warning:
+                self._capture_controls.apply_overlay_state(
+                    enabled=capture.overlay.enabled,
+                    warning=True,
+                )
+            else:
+                self._capture_controls.apply_overlay_state(enabled=state.captions)
 
     def set_peer_auto_detect_available(self, available: bool) -> None:
         self._peer_auto_detect_available = bool(available)

--- a/src/puripuly_heart/ui/views/settings.py
+++ b/src/puripuly_heart/ui/views/settings.py
@@ -17,6 +17,7 @@ import flet as ft
 from puripuly_heart.app.services.local_asr_selection import resolve_local_asr_selection
 from puripuly_heart.core.managed_openrouter_release import TalkTogetherPassStatus
 
+from puripuly_heart.app.ports.ui_models import OscControlPresentationState
 from puripuly_heart.app.services.http_extension_registry import (
     HttpExtensionRegistryService,
 )
@@ -3877,6 +3878,133 @@ class SettingsView(ft.Column):
         self._sync_telemetry_consent_card(settings)
         if is_control_mounted(self):
             _update_control_if_mounted(self._telemetry_consent_card)
+
+    def project_osc_control_state(self, state: OscControlPresentationState) -> None:
+        if self._settings is None:
+            return
+        control = state.changed_control
+        if control in {"PuriPuly_Talk", "PuriPuly_Trans"}:
+            return
+        self._apply_osc_control_state(self._settings, state)
+        if self._provider_settings_draft is not None:
+            self._apply_osc_control_state(self._provider_settings_draft, state)
+        if control in {
+            "PuriPuly_PeerAuto",
+            "PuriPuly_SelfSrcLang",
+            "PuriPuly_SelfDstLang",
+            "PuriPuly_PeerSrcLang",
+            "PuriPuly_PeerDstLang",
+        }:
+            return
+        display_settings = self._build_settings_with_provider_draft()
+        if display_settings is None:
+            return
+        if control in {"PuriPuly_SelfASR", "PuriPuly_PeerASR"}:
+            self._set_unit_card_value_text(
+                self._stt_text,
+                self._stt_provider_display_label(
+                    display_settings.provider.stt,
+                    custom_mode=display_settings.custom_stt.mode,
+                ),
+            )
+            self._set_unit_card_value_text(
+                self._peer_stt_text,
+                self._stt_provider_display_label(
+                    self._effective_peer_stt_provider(display_settings),
+                    custom_mode=display_settings.custom_stt.mode,
+                ),
+            )
+            self._sync_custom_stt_card(display_settings)
+            self._update_api_visibility()
+            _update_control_if_mounted(self._stt_text)
+            _update_control_if_mounted(self._peer_stt_text)
+            _update_control_if_mounted(self._api_keys_column)
+        elif control == "PuriPuly_Translator":
+            self._set_unit_card_value_text(
+                self._llm_text,
+                self._get_llm_display_label(display_settings),
+            )
+            self._set_translation_connection_text(
+                self._get_translation_connection_display_label(display_settings)
+            )
+            self._sync_translation_connection_title(display_settings)
+            self._update_api_visibility()
+            _update_control_if_mounted(self._llm_text)
+            _update_control_if_mounted(self._translation_connection_row)
+            _update_control_if_mounted(self._api_keys_column)
+        elif control == "PuriPuly_Fallback":
+            self._sync_openrouter_fallback_card(display_settings)
+            self._update_api_visibility()
+            _update_control_if_mounted(self._openrouter_fallback_text)
+            _update_control_if_mounted(self._openrouter_fallback_helper_text)
+            _update_control_if_mounted(self._api_keys_column)
+        elif control == "PuriPuly_MuteSync":
+            self._vrc_mic_text.content.value = t(
+                "settings.vrc_mic.on" if state.mute_sync else "settings.vrc_mic.off"
+            )
+            _update_control_if_mounted(self._vrc_mic_text)
+        elif control == "PuriPuly_ChatboxSource":
+            self._chatbox_source_text.content.value = t(
+                "settings.chatbox_source.on"
+                if state.chatbox_source
+                else "settings.chatbox_source.off"
+            )
+            _update_control_if_mounted(self._chatbox_source_text)
+        elif control in {"PuriPuly_Listen", "PuriPuly_Captions"}:
+            self._sync_overlay_controls()
+
+    @staticmethod
+    def _apply_osc_control_state(
+        settings: AppSettings,
+        state: OscControlPresentationState,
+    ) -> None:
+        control = state.changed_control
+        if control == "PuriPuly_SelfSrcLang":
+            settings.languages.source_language = state.self_source_language
+        elif control == "PuriPuly_SelfDstLang":
+            settings.languages.target_language = state.self_target_language
+        elif control == "PuriPuly_PeerSrcLang":
+            settings.languages.peer_source_language = state.peer_source_language
+        elif control == "PuriPuly_PeerDstLang":
+            settings.languages.peer_target_language = state.peer_target_language
+        elif control == "PuriPuly_PeerAuto":
+            settings.languages.peer_source_mode = state.peer_source_mode
+        elif control == "PuriPuly_Listen":
+            settings.ui.peer_translation_enabled = state.peer_capture
+        elif control == "PuriPuly_Captions":
+            settings.ui.overlay_enabled = state.captions
+        elif control == "PuriPuly_MuteSync":
+            settings.osc.vrc_mic_intercept = state.mute_sync
+        elif control == "PuriPuly_ChatboxSource":
+            settings.osc.chatbox_include_source = state.chatbox_source
+        elif control in {"PuriPuly_SelfASR", "PuriPuly_PeerASR"}:
+            if control == "PuriPuly_SelfASR":
+                settings.provider.stt = STTProviderName(state.self_asr_setting)
+            else:
+                settings.provider.peer_stt = STTProviderName(state.peer_asr_setting)
+            settings.custom_stt.mode = state.custom_stt_mode
+            settings.custom_stt.compatibility = state.custom_stt_compatibility
+        elif control == "PuriPuly_Translator":
+            settings.provider.llm = LLMProviderName(state.llm_provider)
+            settings.translation.model = TranslationModel(state.translation_model)
+            settings.translation.connection = TranslationConnection(state.translation_connection)
+            settings.translation.connection_history = {
+                model: TranslationConnection(connection)
+                for model, connection in state.translation_connection_history
+            }
+            settings.translation.http_extension_id = state.translation_http_extension_id
+            settings.translation.previous_llm_model = (
+                None
+                if state.translation_previous_model is None
+                else TranslationModel(state.translation_previous_model)
+            )
+            materialize_translation_settings(settings)
+        elif control == "PuriPuly_Fallback":
+            settings.translation.fallback.enabled = state.fallback_enabled
+            settings.translation.fallback.model = TranslationModel(state.fallback_model)
+            settings.translation.fallback.connection = TranslationConnection(
+                state.fallback_connection
+            )
 
     def _load_secrets(self, settings: AppSettings, config_path: Path) -> None:
         """Load secret values into fields."""

--- a/tests/app/test_osc_control_application.py
+++ b/tests/app/test_osc_control_application.py
@@ -71,16 +71,32 @@ async def test_managed_local_models_control_materializes_provider_and_connection
         translation_model_normalizer=materialize_translation_settings,
     )
 
-    await application.set_translation_model(TranslationModel.MANAGED_GEMMA.value)
+    await application.set_translation_model(
+        TranslationModel.MANAGED_GEMMA.value,
+        TranslationConnection.CPU.value,
+    )
 
     updated = applied[0]
     assert updated.translation.model == TranslationModel.MANAGED_GEMMA
     assert updated.translation.connection == TranslationConnection.CPU
     assert updated.provider.llm == LLMProviderName.MANAGED_GEMMA
 
-    await application.set_translation_model(TranslationModel.MANAGED_GEMMA_12B.value)
+    await application.set_translation_model(
+        TranslationModel.MANAGED_GEMMA.value,
+        TranslationConnection.GPU.value,
+    )
 
     updated = applied[1]
+    assert updated.translation.model == TranslationModel.MANAGED_GEMMA
+    assert updated.translation.connection == TranslationConnection.GPU
+    assert updated.provider.llm == LLMProviderName.MANAGED_GEMMA
+
+    await application.set_translation_model(
+        TranslationModel.MANAGED_GEMMA_12B.value,
+        TranslationConnection.GPU.value,
+    )
+
+    updated = applied[2]
     assert updated.translation.model == TranslationModel.MANAGED_GEMMA_12B
     assert updated.translation.connection == TranslationConnection.GPU
     assert updated.provider.llm == LLMProviderName.MANAGED_GEMMA

--- a/tests/app/test_osc_control_application.py
+++ b/tests/app/test_osc_control_application.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+import copy
+
 import pytest
 
 from puripuly_heart.app.services.osc.control_application import (
+    OscControlApplyResult,
     SettingsBackedOscControlApplication,
 )
 from puripuly_heart.config.settings import (
     AppSettings,
     DeepSeekLLMModel,
     LLMProviderName,
+    STTProviderName,
     TranslationConnection,
     TranslationModel,
     materialize_translation_settings,
@@ -152,6 +156,33 @@ async def test_settings_control_rejects_when_application_keeps_the_previous_stat
 
     assert result is False
     assert current.osc.vrc_mic_intercept is False
+
+
+@pytest.mark.asyncio
+async def test_settings_control_reports_a_committed_normalized_canonical_state() -> None:
+    current = AppSettings()
+    current.provider.stt = STTProviderName.DEEPGRAM
+
+    async def apply_settings(settings: object) -> object:
+        nonlocal current
+        assert isinstance(settings, AppSettings)
+        current = copy.deepcopy(settings)
+        current.provider.stt = STTProviderName.LOCAL_CPU_AUTO
+        return True
+
+    application = SettingsBackedOscControlApplication(
+        settings_provider=lambda: current,
+        apply_settings=apply_settings,
+        translation_model_normalizer=materialize_translation_settings,
+    )
+
+    result = await application.set_self_asr(STTProviderName.LOCAL_QWEN_GPU.value)
+
+    assert result == OscControlApplyResult(
+        applied=False,
+        canonical_state_changed=True,
+    )
+    assert current.provider.stt is STTProviderName.LOCAL_CPU_AUTO
 
 
 @pytest.mark.asyncio

--- a/tests/app/test_osc_control_router.py
+++ b/tests/app/test_osc_control_router.py
@@ -48,8 +48,12 @@ class FakeApplication:
         self.calls.append(("peer_asr", provider))
         return None
 
-    async def set_translation_model(self, model: str) -> object:
-        self.calls.append(("model", model))
+    async def set_translation_model(
+        self,
+        model: str,
+        connection: str | None = None,
+    ) -> object:
+        self.calls.append(("model", (model, connection)))
         return None
 
     async def set_fallback(self, alias: str) -> object:
@@ -167,7 +171,7 @@ async def test_router_routes_the_complete_public_control_matrix() -> None:
         ("languages", ("ja", "en", "en", "ko")),
         ("self_asr", "soniox"),
         ("peer_asr", "local_parakeet_v3"),
-        ("model", "gemini37_flash"),
+        ("model", ("gemini37_flash", None)),
         ("fallback", "none"),
     ]
     assert projected == [name for name, _value in packets]
@@ -181,10 +185,12 @@ async def test_router_routes_on_device_translation_model_ids() -> None:
 
     assert await router.dispatch_packet("/avatar/parameters/PuriPuly_Translator", 10)
     assert await router.dispatch_packet("/avatar/parameters/PuriPuly_Translator", 11)
+    assert await router.dispatch_packet("/avatar/parameters/PuriPuly_Translator", 12)
 
     assert application.calls == [
-        ("model", "managed_gemma"),
-        ("model", "managed_gemma_12b"),
+        ("model", ("managed_gemma", "cpu")),
+        ("model", ("managed_gemma", "gpu")),
+        ("model", ("managed_gemma_12b", "gpu")),
     ]
     await router.close()
 
@@ -509,7 +515,7 @@ async def test_router_skips_a_cancelled_pending_coalesced_command() -> None:
     application.gate.set()
     assert (await first).applied is True
 
-    assert ("model", "gemini37_flash") not in application.calls
+    assert ("model", ("gemini37_flash", None)) not in application.calls
     assert projected == ["PuriPuly_SelfASR"]
     await router.close()
 

--- a/tests/app/test_osc_control_router.py
+++ b/tests/app/test_osc_control_router.py
@@ -115,7 +115,11 @@ async def test_router_publishes_canonical_delta_after_successful_application() -
 async def test_router_routes_the_complete_public_control_matrix() -> None:
     application = FakeApplication()
     application.gate.set()
-    router = OscControlRouter(application)
+    projected: list[str] = []
+    router = OscControlRouter(
+        application,
+        canonical_state_projector=projected.append,
+    )
 
     packets = [
         ("PuriPuly_Talk", True),
@@ -166,6 +170,7 @@ async def test_router_routes_the_complete_public_control_matrix() -> None:
         ("model", "gemini37_flash"),
         ("fallback", "none"),
     ]
+    assert projected == [name for name, _value in packets]
     await router.close()
 
 
@@ -187,29 +192,47 @@ async def test_router_routes_on_device_translation_model_ids() -> None:
 @pytest.mark.asyncio
 async def test_router_coalesces_superseded_expensive_controls() -> None:
     application = FakeApplication()
-    router = OscControlRouter(application)
+    projected: list[tuple[str, object]] = []
+
+    def project(control: str) -> None:
+        projected.append((control, application.calls[-1][1]))
+
+    router = OscControlRouter(
+        application,
+        canonical_state_projector=project,
+    )
 
     first = asyncio.create_task(router.dispatch_packet("/avatar/parameters/PuriPuly_SelfASR", 1))
     await asyncio.sleep(0)
-    second = asyncio.create_task(router.dispatch_packet("/avatar/parameters/PuriPuly_SelfASR", 7))
+    second = asyncio.create_task(router.dispatch_packet("/avatar/parameters/PuriPuly_SelfASR", 4))
+    await asyncio.sleep(0)
+    third = asyncio.create_task(router.dispatch_packet("/avatar/parameters/PuriPuly_SelfASR", 7))
     await asyncio.sleep(0)
     application.gate.set()
 
-    first_result, second_result = await asyncio.gather(first, second)
+    first_result, second_result, third_result = await asyncio.gather(first, second, third)
 
-    assert first_result.applied is True or first_result.superseded is True
-    assert second_result.applied is True
+    assert first_result.applied is True
+    assert second_result.applied is False
+    assert second_result.superseded is True
+    assert third_result.applied is True
     assert application.calls[-1] == ("self_asr", "soniox")
+    assert projected == [
+        ("PuriPuly_SelfASR", "local_parakeet_v3"),
+        ("PuriPuly_SelfASR", "soniox"),
+    ]
     await router.close()
 
 
 @pytest.mark.asyncio
 async def test_router_suppresses_values_echoed_from_its_publisher() -> None:
     application = FakeApplication()
+    projected: list[str] = []
     router = OscControlRouter(
         application,
         echo_suppression_provider=lambda message: message.name == "PuriPuly_Talk"
         and message.value is True,
+        canonical_state_projector=projected.append,
     )
 
     result = await router.dispatch_packet("/avatar/parameters/PuriPuly_Talk", True)
@@ -217,6 +240,7 @@ async def test_router_suppresses_values_echoed_from_its_publisher() -> None:
     assert result.applied is False
     assert result.error == "echo_suppressed"
     assert application.calls == []
+    assert projected == []
     await router.close()
 
 
@@ -257,6 +281,7 @@ async def test_router_republishes_canonical_state_after_invalid_id() -> None:
     application = FakeApplication()
     delta_republish_calls = 0
     full_republish_calls = 0
+    projected: list[str] = []
 
     def republish_delta() -> None:
         nonlocal delta_republish_calls
@@ -270,19 +295,26 @@ async def test_router_republishes_canonical_state_after_invalid_id() -> None:
         application,
         canonical_state_republisher=republish_delta,
         canonical_state_full_republisher=republish_full,
+        canonical_state_projector=projected.append,
     )
 
     assert router.handle_packet("/avatar/parameters/PuriPuly_SelfASR", 99) is False
+    assert router.handle_packet("/avatar/parameters/PuriPuly_Talk", 1) is False
     assert delta_republish_calls == 0
-    assert full_republish_calls == 1
+    assert full_republish_calls == 2
     assert application.calls == []
+    assert projected == []
     await router.close()
 
 
 @pytest.mark.asyncio
 async def test_router_resolves_inflight_coalesced_command_when_closed() -> None:
     application = FakeApplication()
-    router = OscControlRouter(application)
+    projected: list[str] = []
+    router = OscControlRouter(
+        application,
+        canonical_state_projector=projected.append,
+    )
     dispatch_task = asyncio.create_task(
         router.dispatch_packet("/avatar/parameters/PuriPuly_SelfASR", 1)
     )
@@ -293,12 +325,48 @@ async def test_router_resolves_inflight_coalesced_command_when_closed() -> None:
     result = await asyncio.wait_for(dispatch_task, timeout=1)
     assert result.applied is False
     assert result.error == "router_closed"
+    assert projected == []
+
+
+@pytest.mark.asyncio
+async def test_router_does_not_project_when_application_suppresses_close_cancellation() -> None:
+    class CancellationSuppressingApplication(FakeApplication):
+        async def set_self_asr(self, provider: str) -> object:
+            self.started.set()
+            try:
+                await self.gate.wait()
+            except asyncio.CancelledError:
+                self.calls.append(("cancelled_self_asr", provider))
+            return None
+
+    application = CancellationSuppressingApplication()
+    projected: list[str] = []
+    router = OscControlRouter(
+        application,
+        canonical_state_projector=projected.append,
+    )
+    dispatch_task = asyncio.create_task(
+        router.dispatch_packet("/avatar/parameters/PuriPuly_SelfASR", 1)
+    )
+    await application.started.wait()
+
+    await router.close()
+
+    result = await asyncio.wait_for(dispatch_task, timeout=1)
+    assert result.applied is False
+    assert result.error == "router_closed"
+    assert application.calls == [("cancelled_self_asr", "local_parakeet_v3")]
+    assert projected == []
 
 
 @pytest.mark.asyncio
 async def test_router_drains_started_command_after_ingress_is_disabled() -> None:
     application = FakeApplication()
-    router = OscControlRouter(application)
+    projected: list[str] = []
+    router = OscControlRouter(
+        application,
+        canonical_state_projector=projected.append,
+    )
     dispatch_task = asyncio.create_task(
         router.dispatch_packet("/avatar/parameters/PuriPuly_SelfASR", 1)
     )
@@ -308,16 +376,21 @@ async def test_router_drains_started_command_after_ingress_is_disabled() -> None
     application.gate.set()
 
     result = await asyncio.wait_for(dispatch_task, timeout=1)
-    assert result.applied is True
-    assert result.error is None
+    assert result.applied is False
+    assert result.error == "router_disabled"
     assert ("self_asr", "local_parakeet_v3") in application.calls
+    assert projected == []
     await router.close()
 
 
 @pytest.mark.asyncio
 async def test_router_rechecks_generation_after_waiting_for_serial_lock() -> None:
     application = FakeApplication()
-    router = OscControlRouter(application)
+    projected: list[str] = []
+    router = OscControlRouter(
+        application,
+        canonical_state_projector=projected.append,
+    )
     first = asyncio.create_task(router.dispatch_packet("/avatar/parameters/PuriPuly_SelfASR", 1))
     await application.started.wait()
 
@@ -328,12 +401,13 @@ async def test_router_rechecks_generation_after_waiting_for_serial_lock() -> Non
 
     first_result, second_result = await asyncio.gather(first, second)
 
-    assert first_result.applied is True
-    assert first_result.error is None
+    assert first_result.applied is False
+    assert first_result.error == "router_disabled"
     assert second_result.applied is False
     assert second_result.error == "router_disabled"
     assert ("self_asr", "local_parakeet_v3") in application.calls
     assert ("self_capture", True) not in application.calls
+    assert projected == []
     await router.close()
 
 
@@ -347,6 +421,7 @@ async def test_router_republishes_after_rejected_application_result(
 ) -> None:
     application = RejectingApplication(application_result)
     full_republish_calls = 0
+    projected: list[str] = []
 
     def republish_full() -> None:
         nonlocal full_republish_calls
@@ -355,6 +430,7 @@ async def test_router_republishes_after_rejected_application_result(
     router = OscControlRouter(
         application,
         canonical_state_full_republisher=republish_full,
+        canonical_state_projector=projected.append,
     )
 
     result = await router.dispatch_packet("/avatar/parameters/PuriPuly_Trans", True)
@@ -362,6 +438,7 @@ async def test_router_republishes_after_rejected_application_result(
     assert result.applied is False
     assert result.error == "application_rejected"
     assert full_republish_calls == 1
+    assert projected == []
     await router.close()
 
 
@@ -373,6 +450,7 @@ async def test_router_republishes_after_application_exception() -> None:
 
     application = RaisingApplication()
     full_republish_calls = 0
+    projected: list[str] = []
 
     def republish_full() -> None:
         nonlocal full_republish_calls
@@ -381,6 +459,7 @@ async def test_router_republishes_after_application_exception() -> None:
     router = OscControlRouter(
         application,
         canonical_state_full_republisher=republish_full,
+        canonical_state_projector=projected.append,
     )
 
     result = await router.dispatch_packet("/avatar/parameters/PuriPuly_Trans", True)
@@ -388,4 +467,150 @@ async def test_router_republishes_after_application_exception() -> None:
     assert result.applied is False
     assert result.error == "RuntimeError"
     assert full_republish_calls == 1
+    assert projected == []
+    await router.close()
+
+
+@pytest.mark.asyncio
+async def test_router_projects_canonical_state_after_a_normalized_rejection() -> None:
+    application = RejectingApplication(SimpleNamespace(applied=False, canonical_state_changed=True))
+    projected: list[str] = []
+    router = OscControlRouter(
+        application,
+        canonical_state_projector=projected.append,
+    )
+
+    result = await router.dispatch_packet("/avatar/parameters/PuriPuly_Trans", True)
+
+    assert result.applied is False
+    assert result.error == "application_rejected"
+    assert projected == ["PuriPuly_Trans"]
+    await router.close()
+
+
+@pytest.mark.asyncio
+async def test_router_skips_a_cancelled_pending_coalesced_command() -> None:
+    application = FakeApplication()
+    projected: list[str] = []
+    router = OscControlRouter(
+        application,
+        canonical_state_projector=projected.append,
+    )
+    first = asyncio.create_task(router.dispatch_packet("/avatar/parameters/PuriPuly_SelfASR", 1))
+    await application.started.wait()
+    cancelled = asyncio.create_task(
+        router.dispatch_packet("/avatar/parameters/PuriPuly_Translator", 5)
+    )
+    await asyncio.sleep(0)
+
+    cancelled.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await cancelled
+    application.gate.set()
+    assert (await first).applied is True
+
+    assert ("model", "gemini37_flash") not in application.calls
+    assert projected == ["PuriPuly_SelfASR"]
+    await router.close()
+
+
+@pytest.mark.asyncio
+async def test_router_does_not_project_a_cancelled_inflight_coalesced_command() -> None:
+    application = FakeApplication()
+    projected: list[str] = []
+    router = OscControlRouter(
+        application,
+        canonical_state_projector=projected.append,
+    )
+    cancelled = asyncio.create_task(
+        router.dispatch_packet("/avatar/parameters/PuriPuly_SelfASR", 1)
+    )
+    await application.started.wait()
+
+    cancelled.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await cancelled
+    application.gate.set()
+    followup = await router.dispatch_packet("/avatar/parameters/PuriPuly_Talk", True)
+
+    assert followup.applied is True
+    assert ("self_asr", "local_parakeet_v3") in application.calls
+    assert projected == ["PuriPuly_Talk"]
+    await router.close()
+
+
+@pytest.mark.asyncio
+async def test_router_does_not_project_when_application_suppresses_caller_cancellation() -> None:
+    class CancellationSuppressingApplication(FakeApplication):
+        async def set_self_capture(self, enabled: bool) -> object:
+            self.started.set()
+            try:
+                await self.gate.wait()
+            except asyncio.CancelledError:
+                self.calls.append(("cancelled_self_capture", enabled))
+            return None
+
+    application = CancellationSuppressingApplication()
+    projected: list[str] = []
+    router = OscControlRouter(
+        application,
+        canonical_state_projector=projected.append,
+    )
+    dispatch_task = asyncio.create_task(
+        router.dispatch_packet("/avatar/parameters/PuriPuly_Talk", True)
+    )
+    await application.started.wait()
+
+    dispatch_task.cancel()
+    result = await dispatch_task
+
+    assert result.applied is False
+    assert result.error == "cancelled"
+    assert application.calls == [("cancelled_self_capture", True)]
+    assert projected == []
+    await router.close()
+
+
+@pytest.mark.asyncio
+async def test_router_keeps_success_when_projector_raises_after_publication() -> None:
+    application = FakeApplication()
+    events: list[str] = []
+
+    def project(_control: str) -> None:
+        events.append("project")
+        raise RuntimeError("presentation unavailable")
+
+    router = OscControlRouter(
+        application,
+        canonical_state_republisher=lambda: events.append("publish"),
+        canonical_state_projector=project,
+    )
+
+    result = await router.dispatch_packet("/avatar/parameters/PuriPuly_Trans", True)
+
+    assert result.applied is True
+    assert events == ["publish", "project"]
+    await router.close()
+
+
+@pytest.mark.asyncio
+async def test_router_rechecks_generation_after_outbound_publication() -> None:
+    application = FakeApplication()
+    projected: list[str] = []
+    router: OscControlRouter
+
+    def publish_delta() -> None:
+        router.set_ingress_enabled(False)
+
+    router = OscControlRouter(
+        application,
+        canonical_state_republisher=publish_delta,
+        canonical_state_projector=projected.append,
+    )
+
+    result = await router.dispatch_packet("/avatar/parameters/PuriPuly_Trans", True)
+
+    assert result.applied is False
+    assert result.error == "router_disabled"
+    assert projected == []
     await router.close()

--- a/tests/app/test_osc_control_runtime.py
+++ b/tests/app/test_osc_control_runtime.py
@@ -1,20 +1,35 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 from collections.abc import Callable
 from dataclasses import dataclass
 
 import pytest
 
-from puripuly_heart.app.ports.osc_control import OSC_PARAMETER_DEFINITIONS
+from puripuly_heart.app.ports.osc_control import ASR_ID_BY_PROVIDER, OSC_PARAMETER_DEFINITIONS
 from puripuly_heart.app.ports.oscquery import (
     OscQueryAdvertisement,
     OscQueryServiceInfo,
 )
+from puripuly_heart.app.ports.ui_models import (
+    OscControlPresentationName,
+    OscControlPresentationState,
+)
 from puripuly_heart.app.services.osc import control_runtime as control_runtime_module
 from puripuly_heart.app.services.osc.control_runtime import OscControlIntegrationOwner
-from puripuly_heart.app.services.osc.state_publisher import OscCanonicalState
-from puripuly_heart.config.settings import AppSettings, materialize_translation_settings
+from puripuly_heart.app.services.osc.presentation_state import (
+    presentation_state_from_settings,
+)
+from puripuly_heart.app.services.osc.state_publisher import (
+    OscCanonicalState,
+    state_from_settings,
+)
+from puripuly_heart.config.settings import (
+    AppSettings,
+    STTProviderName,
+    materialize_translation_settings,
+)
 
 
 class FakeSender:
@@ -241,6 +256,160 @@ def _integration(
         query_service=service,
         resync_timeout_seconds=resync_timeout_seconds,
     )
+
+
+@pytest.mark.asyncio
+async def test_in_process_complete_control_matrix_projects_final_canonical_state() -> None:
+    current = [AppSettings()]
+    runtime = {
+        "self_capture": False,
+        "peer_capture": False,
+        "translation": False,
+    }
+    runtime_calls: list[tuple[str, bool]] = []
+    settings_apply_calls: list[AppSettings] = []
+    projected: list[OscControlPresentationState] = []
+
+    class CanonicalDashboardApplication:
+        async def set_stt_enabled(self, enabled: bool) -> None:
+            runtime["self_capture"] = enabled
+            runtime_calls.append(("self_capture", enabled))
+
+        async def set_peer_translation_enabled(self, enabled: bool) -> None:
+            runtime["peer_capture"] = enabled
+            runtime_calls.append(("peer_capture", enabled))
+
+        async def set_translation_enabled(self, enabled: bool) -> None:
+            runtime["translation"] = enabled
+            runtime_calls.append(("translation", enabled))
+
+        async def set_overlay_enabled(self, enabled: bool) -> None:
+            current[0].ui.overlay_enabled = enabled
+            runtime_calls.append(("captions", enabled))
+
+    async def apply_settings(value: object) -> None:
+        assert isinstance(value, AppSettings)
+        current[0] = value
+        settings_apply_calls.append(value)
+
+    def canonical_state() -> OscCanonicalState:
+        return state_from_settings(
+            current[0],
+            self_capture=runtime["self_capture"],
+            peer_capture=runtime["peer_capture"],
+            translation=runtime["translation"],
+            captions=current[0].ui.overlay_enabled,
+        )
+
+    def presentation_state(
+        control: OscControlPresentationName,
+    ) -> OscControlPresentationState:
+        return presentation_state_from_settings(
+            current[0],
+            canonical_state=canonical_state(),
+            changed_control=control,
+        )
+
+    receiver_owner = FakeReceiverOwner()
+    sender = FakeSender()
+    application = CanonicalDashboardApplication()
+    integration = OscControlIntegrationOwner(
+        receiver_owner=receiver_owner,
+        settings_provider=lambda: current[0],
+        apply_settings=apply_settings,
+        application_provider=lambda: application,
+        sender_provider=lambda: sender,
+        state_provider=canonical_state,
+        language_state_provider=lambda: (
+            current[0].languages.source_language,
+            current[0].languages.target_language,
+            current[0].languages.peer_source_language,
+            current[0].languages.peer_target_language,
+        ),
+        translation_model_normalizer=materialize_translation_settings,
+        ui_state_provider=presentation_state,
+        ui_state_sink=projected.append,
+        query_service=FakeService(None),
+    )
+    packets: list[tuple[OscControlPresentationName, bool | int]] = [
+        ("PuriPuly_Talk", True),
+        ("PuriPuly_Listen", True),
+        ("PuriPuly_Trans", True),
+        ("PuriPuly_Captions", True),
+        ("PuriPuly_PeerAuto", True),
+        ("PuriPuly_MuteSync", True),
+        ("PuriPuly_ChatboxSource", True),
+        ("PuriPuly_SelfSrcLang", 16),
+        ("PuriPuly_SelfDstLang", 11),
+        ("PuriPuly_PeerSrcLang", 5),
+        ("PuriPuly_PeerDstLang", 7),
+        ("PuriPuly_SelfASR", 7),
+        ("PuriPuly_PeerASR", 4),
+        ("PuriPuly_Translator", 5),
+        ("PuriPuly_Fallback", 1),
+    ]
+
+    for name, value in packets:
+        result = await integration.router.dispatch_packet(
+            f"/avatar/parameters/{name}",
+            value,
+        )
+
+        assert result.applied is True
+        assert projected[-1] == presentation_state(name)
+
+    assert [state.changed_control for state in projected] == [name for name, _value in packets]
+    assert len(runtime_calls) == 4
+    assert len(settings_apply_calls) == 11
+    assert sender.messages == []
+    await integration.close()
+
+
+@pytest.mark.asyncio
+async def test_normalized_asr_rejection_projects_the_committed_canonical_fallback() -> None:
+    current = [AppSettings()]
+    current[0].provider.stt = STTProviderName.DEEPGRAM
+    projected: list[OscControlPresentationState] = []
+
+    async def apply_settings(value: object) -> None:
+        assert isinstance(value, AppSettings)
+        normalized = copy.deepcopy(value)
+        normalized.provider.stt = STTProviderName.LOCAL_CPU_AUTO
+        current[0] = normalized
+
+    def canonical_state() -> OscCanonicalState:
+        return state_from_settings(current[0])
+
+    integration = OscControlIntegrationOwner(
+        receiver_owner=FakeReceiverOwner(),
+        settings_provider=lambda: current[0],
+        apply_settings=apply_settings,
+        application_provider=lambda: None,
+        sender_provider=lambda: FakeSender(),
+        state_provider=canonical_state,
+        language_state_provider=lambda: ("ko", "en", "en", "ko"),
+        translation_model_normalizer=materialize_translation_settings,
+        ui_state_provider=lambda control: presentation_state_from_settings(
+            current[0],
+            canonical_state=canonical_state(),
+            changed_control=control,
+        ),
+        ui_state_sink=projected.append,
+        query_service=FakeService(None),
+    )
+
+    result = await integration.router.dispatch_packet(
+        "/avatar/parameters/PuriPuly_SelfASR",
+        ASR_ID_BY_PROVIDER[STTProviderName.LOCAL_QWEN_GPU.value],
+    )
+
+    assert result.applied is False
+    assert result.error == "application_rejected"
+    assert current[0].provider.stt is STTProviderName.LOCAL_CPU_AUTO
+    assert len(projected) == 1
+    assert projected[0].changed_control == "PuriPuly_SelfASR"
+    assert projected[0].self_asr_setting == STTProviderName.LOCAL_CPU_AUTO.value
+    await integration.close()
 
 
 @pytest.mark.asyncio
@@ -1018,8 +1187,8 @@ async def test_off_transition_drains_an_admitted_dashboard_command() -> None:
         asyncio.gather(dispatch_task, off_task),
         timeout=1,
     )
-    assert result.applied is True
-    assert result.error is None
+    assert result.applied is False
+    assert result.error == "router_disabled"
     assert application.completed is True
     assert integration.connection_mode == "off"
     assert len(sender.messages) == 16

--- a/tests/app/test_osc_presentation_state.py
+++ b/tests/app/test_osc_presentation_state.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from puripuly_heart.app.services.osc.presentation_state import (
+    presentation_state_from_settings,
+)
+from puripuly_heart.app.services.osc.state_publisher import state_from_settings
+from puripuly_heart.config.settings import (
+    AppSettings,
+    STTProviderName,
+    TranslationConnection,
+    TranslationModel,
+)
+
+
+def test_presentation_state_captures_the_post_apply_canonical_snapshot() -> None:
+    settings = AppSettings()
+    settings.languages.source_language = "ja"
+    settings.provider.stt = STTProviderName.SONIOX
+    settings.translation.model = TranslationModel.GEMINI_37_FLASH
+    settings.translation.connection = TranslationConnection.OFFICIAL_BYOK
+    canonical = state_from_settings(
+        settings,
+        self_capture=True,
+        translation=True,
+    )
+
+    state = presentation_state_from_settings(
+        settings,
+        canonical_state=canonical,
+        changed_control="PuriPuly_Translator",
+        self_capture_effective=False,
+    )
+
+    assert state.changed_control == "PuriPuly_Translator"
+    assert state.self_capture is False
+    assert state.translation is True
+    assert state.self_source_language == "ja"
+    assert state.self_asr == "soniox"
+    assert state.self_asr_setting == STTProviderName.SONIOX.value
+    assert state.translation_model == TranslationModel.GEMINI_37_FLASH.value
+    assert state.translation_connection == TranslationConnection.OFFICIAL_BYOK.value
+    assert isinstance(state.translation_connection_history, tuple)
+    with pytest.raises(FrozenInstanceError):
+        setattr(state, "translation", False)

--- a/tests/app/test_settings_application_owner.py
+++ b/tests/app/test_settings_application_owner.py
@@ -20,6 +20,9 @@ from puripuly_heart.app.services.canonical_settings_persistence import SettingsO
 from puripuly_heart.app.services.manual_local_asr_fallback import (
     ManualLocalASRFallbackOwner,
 )
+from puripuly_heart.app.services.settings import (
+    settings_application as settings_application_module,
+)
 from puripuly_heart.config.settings import AppSettings, to_dict
 from puripuly_heart.config.settings_vnext.schema import AppSettingsVNext
 from puripuly_heart.core.messages import (
@@ -105,6 +108,7 @@ class FakeRuntimeEffects:
     ) -> None:
         self.events = events
         self.failure = failure
+        self.reload_settings_view: list[bool] = []
 
     async def preserve_before_replace(self, _settings: AppSettings) -> None:
         self.events.append("preserve")
@@ -170,9 +174,10 @@ class FakeRuntimeEffects:
     async def apply_after_persist(
         self,
         _transition: SettingsRuntimeTransition[AppSettings],
-        **_kwargs: object,
+        **kwargs: object,
     ) -> None:
         self.events.append("runtime")
+        self.reload_settings_view.append(bool(kwargs.get("reload_settings_view", True)))
         if self.failure is not None:
             raise self.failure
 
@@ -233,6 +238,63 @@ async def test_settings_application_owner_routes_mixed_surfaces_in_transaction_o
     assert (
         owner.results.current.status == TRANSACTION_STATUS_SETTINGS_COMMIT_SUCCESS_RUNTIME_APPLIED
     )
+
+
+@pytest.mark.asyncio
+async def test_settings_application_owner_can_suppress_language_view_reload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = FakeSettingsOwner(AppSettings())
+    renders: list[object] = []
+    projection = SettingsProjectionOwner(
+        presentation=SimpleNamespace(
+            render_settings=lambda *args, **_kwargs: renders.append(args[0])
+        ),
+        config_path=Path("settings.json"),
+        current_settings=lambda: settings.current,
+    )
+    projection.remember_all(settings.current)
+    effects = FakeRuntimeEffects([])
+
+    class ApplyingMutationService:
+        def __init__(self, *, runtime_apply: object, **_kwargs: object) -> None:
+            self.runtime_apply = runtime_apply
+
+        async def mutate(self, _request: object) -> TransactionResult:
+            await self.runtime_apply.apply_runtime(SimpleNamespace())
+            return TransactionResult(
+                status=TRANSACTION_STATUS_SETTINGS_COMMIT_SUCCESS_RUNTIME_APPLIED,
+                message=None,
+                diagnostics=None,
+            )
+
+    monkeypatch.setattr(
+        settings_application_module,
+        "SettingsMutationService",
+        ApplyingMutationService,
+    )
+    owner = SettingsApplicationOwner(
+        settings=settings,
+        projection=projection,
+        runtime_effects=effects,
+        manual_fallback=ManualLocalASRFallbackOwner(),
+        cpu_auto_available=lambda: True,
+        inspect_cpu=lambda: None,
+        fallback_sink=lambda _channels, _installation: None,
+        sync_ui=lambda: None,
+        fallback_log_sink=lambda _previous, _normalized, _channels: None,
+        mutation_service_provider=lambda: None,
+        consume_superseded_settings=lambda _settings: False,
+        active_local_asr_change=lambda _base, _next: False,
+        failure_sink=lambda _message: None,
+    )
+    pending = copy.deepcopy(settings.current)
+    pending.languages.source_language = "ja"
+
+    assert await owner.apply(pending, reload_settings_view=False)
+
+    assert effects.reload_settings_view == [False]
+    assert renders == []
 
 
 @pytest.mark.asyncio

--- a/tests/architecture/test_composition_factory_exclusivity.py
+++ b/tests/architecture/test_composition_factory_exclusivity.py
@@ -28,6 +28,9 @@ CASES = [
         "required_snippets": (
             "configure_vrc_mic=lambda *, enabled: "
             "(require_vrc_mic_sync().configure(enabled=enabled))",
+            "ui_state_provider=osc_ui_state",
+            "ui_state_sink=presentation.project_osc_control_state",
+            "reload_settings_view=False",
         ),
         "retired_names": ("def _stop_vrc_mic_receiver(",),
     },

--- a/tests/core/test_osc_control_protocol.py
+++ b/tests/core/test_osc_control_protocol.py
@@ -18,6 +18,8 @@ from puripuly_heart.core.osc.control_schema import (
     OSC_BOOLEAN_PARAMETER_NAMES,
     OSC_INTEGER_PARAMETER_NAMES,
     OSC_PARAMETER_DEFINITIONS,
+    TRANSLATION_CONNECTION_BY_MODEL_ID,
+    TRANSLATION_MODEL_ID_BY_SELECTION,
     TRANSLATION_MODEL_IDS,
 )
 
@@ -113,7 +115,7 @@ def test_osc_public_abi_snapshot_is_append_only_and_exact() -> None:
         "PuriPuly_PeerDstLang": "languages.peer_target_language",
         "PuriPuly_SelfASR": "stt.provider",
         "PuriPuly_PeerASR": "peer_stt.provider",
-        "PuriPuly_Translator": "translation.model",
+        "PuriPuly_Translator": "translation.selection",
         "PuriPuly_Fallback": "translation.fallback",
     }
     assert tuple(
@@ -133,7 +135,7 @@ def test_osc_public_abi_snapshot_is_append_only_and_exact() -> None:
         ("PuriPuly_PeerDstLang", "int", "languages.peer_target_language"),
         ("PuriPuly_SelfASR", "int", "stt.provider"),
         ("PuriPuly_PeerASR", "int", "peer_stt.provider"),
-        ("PuriPuly_Translator", "int", "translation.model"),
+        ("PuriPuly_Translator", "int", "translation.selection"),
         ("PuriPuly_Fallback", "int", "translation.fallback"),
     )
     assert dict(ASR_IDS) == {
@@ -159,7 +161,18 @@ def test_osc_public_abi_snapshot_is_append_only_and_exact() -> None:
         8: "local_llm",
         9: "custom_http",
         10: "managed_gemma",
-        11: "managed_gemma_12b",
+        11: "managed_gemma",
+        12: "managed_gemma_12b",
+    }
+    assert dict(TRANSLATION_CONNECTION_BY_MODEL_ID) == {
+        10: "cpu",
+        11: "gpu",
+        12: "gpu",
+    }
+    assert dict(TRANSLATION_MODEL_ID_BY_SELECTION) == {
+        ("managed_gemma", "cpu"): 10,
+        ("managed_gemma", "gpu"): 11,
+        ("managed_gemma_12b", "gpu"): 12,
     }
     assert dict(FALLBACK_IDS) == {
         0: "none",

--- a/tests/core/test_osc_state_publisher.py
+++ b/tests/core/test_osc_state_publisher.py
@@ -64,10 +64,11 @@ def test_state_publisher_full_snapshot_republishes_after_discovery() -> None:
         (TranslationModel.GEMMA4_31B, TranslationConnection.CEREBRAS, 1),
         (TranslationModel.CUSTOM_HTTP, TranslationConnection.CUSTOM_HTTP, 9),
         (TranslationModel.MANAGED_GEMMA, TranslationConnection.CPU, 10),
-        (TranslationModel.MANAGED_GEMMA_12B, TranslationConnection.GPU, 11),
+        (TranslationModel.MANAGED_GEMMA, TranslationConnection.GPU, 11),
+        (TranslationModel.MANAGED_GEMMA_12B, TranslationConnection.GPU, 12),
     ],
 )
-def test_state_publisher_uses_product_level_translation_model_ids(
+def test_state_publisher_uses_translation_selection_ids(
     model: TranslationModel,
     connection: TranslationConnection,
     expected_id: int,

--- a/tests/helpers/osc_presentation.py
+++ b/tests/helpers/osc_presentation.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from puripuly_heart.app.ports.ui_models import (
+    OscControlPresentationName,
+    OscControlPresentationState,
+)
+from puripuly_heart.app.services.osc.presentation_state import (
+    presentation_state_from_settings,
+)
+from puripuly_heart.app.services.osc.state_publisher import OscCanonicalState, state_from_settings
+from puripuly_heart.config.settings import AppSettings
+
+
+def osc_control_presentation_state(
+    changed_control: OscControlPresentationName,
+    *,
+    settings: AppSettings | None = None,
+    canonical_state: OscCanonicalState | None = None,
+    **canonical_changes: object,
+) -> OscControlPresentationState:
+    value = settings or AppSettings()
+    canonical = canonical_state or state_from_settings(value)
+    if canonical_changes:
+        canonical = replace(canonical, **canonical_changes)
+    return presentation_state_from_settings(
+        value,
+        canonical_state=canonical,
+        changed_control=changed_control,
+    )
+
+
+__all__ = ["osc_control_presentation_state"]

--- a/tests/ui/test_dashboard_view_branches.py
+++ b/tests/ui/test_dashboard_view_branches.py
@@ -8,6 +8,7 @@ import pytest
 ft = pytest.importorskip("flet")
 
 from puripuly_heart.app.ports.ui_models import ManagedGemmaDashboardNotice
+from puripuly_heart.config.settings import AppSettings, STTProviderName
 from puripuly_heart.ui.dashboard import capture as dashboard_capture_module
 from puripuly_heart.ui.dashboard.contract import (
     DashboardCaptureIntents,
@@ -20,6 +21,7 @@ from puripuly_heart.ui.overlay_peer_contract import (
 )
 from puripuly_heart.ui.views import dashboard as dashboard_module
 from tests.helpers.flet_page import attach_dummy_page
+from tests.helpers.osc_presentation import osc_control_presentation_state
 
 
 class FakePowerButton:
@@ -159,6 +161,7 @@ class FakeLanguageCard:
 class FakeLanguageModal:
     opened: list[tuple[str, list[str]]] = []
     languages: list[tuple[str, str]] = []
+    disabled_codes: list[set[str]] = []
 
     def __init__(
         self,
@@ -169,8 +172,9 @@ class FakeLanguageModal:
         description_for_code=None,
         disabled_codes=None,
     ):
-        _ = (page, label_for_code, description_for_code, disabled_codes)
+        _ = (page, label_for_code, description_for_code)
         self.__class__.languages = list(languages)
+        self.__class__.disabled_codes.append(set(disabled_codes or ()))
         self.on_select = on_select
 
     def open(self, *, current: str, recent: list[str]) -> None:
@@ -188,6 +192,7 @@ def _make_dashboard(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(dashboard_module, "get_locale", lambda: "en")
     view = dashboard_module.DashboardView()
     FakeLanguageModal.opened = []
+    FakeLanguageModal.disabled_codes = []
     return view
 
 
@@ -492,6 +497,155 @@ def test_dashboard_public_setters_update_components(monkeypatch: pytest.MonkeyPa
         "helper_text": None,
     }
     assert view._recent_source_langs == ["a", "b", "c", "d", "e", "f"]
+
+
+def test_dashboard_projects_osc_state_without_emitting_intents(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    view = _make_dashboard(monkeypatch)
+    attach_dummy_page(monkeypatch, view)
+    emitted: list[tuple[str, object]] = []
+    view.on_toggle_stt = lambda value: emitted.append(("stt", value))
+    view.on_toggle_translation = lambda value: emitted.append(("translation", value))
+    view.on_toggle_peer_translation = lambda value: emitted.append(("peer", value))
+    view.on_toggle_overlay = lambda value: emitted.append(("captions", value))
+    view.on_language_change = lambda value: emitted.append(("languages", value))
+    settings = AppSettings()
+    settings.languages.source_language = "ja"
+    settings.languages.target_language = "fr"
+    settings.languages.peer_source_language = "de"
+    settings.languages.peer_target_language = "ko"
+    settings.languages.peer_source_mode = "auto"
+    settings.provider.peer_stt = STTProviderName.SONIOX
+
+    view.project_osc_control_state(
+        osc_control_presentation_state(
+            "PuriPuly_Talk",
+            settings=settings,
+            self_capture=True,
+        )
+    )
+    view.project_osc_control_state(
+        osc_control_presentation_state(
+            "PuriPuly_Trans",
+            settings=settings,
+            translation=True,
+        )
+    )
+    view.project_osc_control_state(
+        osc_control_presentation_state(
+            "PuriPuly_SelfSrcLang",
+            settings=settings,
+        )
+    )
+    unavailable_settings = AppSettings()
+    unavailable_settings.provider.peer_stt = STTProviderName.LOCAL_PARAKEET_V3
+    view.project_osc_control_state(
+        osc_control_presentation_state(
+            "PuriPuly_PeerASR",
+            settings=unavailable_settings,
+        )
+    )
+    view.language_card.on_peer_source_click()
+    view.project_osc_control_state(
+        osc_control_presentation_state(
+            "PuriPuly_PeerASR",
+            settings=settings,
+        )
+    )
+    view.language_card.on_peer_source_click()
+    view.project_osc_control_state(
+        osc_control_presentation_state(
+            "PuriPuly_Listen",
+            settings=settings,
+            peer_capture=True,
+        )
+    )
+    view.project_osc_control_state(
+        osc_control_presentation_state(
+            "PuriPuly_Captions",
+            settings=settings,
+            captions=True,
+        )
+    )
+
+    assert view.is_stt_on is True
+    assert view.is_translation_on is True
+    assert view.language_card.languages[-1] == (
+        "name-ja",
+        "name-fr",
+        dashboard_module.t("dashboard.peer_source.automatic"),
+        "name-ko",
+    )
+    assert FakeLanguageModal.disabled_codes[-2:] == [{"auto"}, set()]
+    assert view.peer_button.states[-1]["is_on"] is True
+    assert view.overlay_button.states[-1]["is_on"] is True
+    assert emitted == []
+
+
+def test_dashboard_osc_projection_preserves_rich_peer_and_overlay_states(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    view = _make_dashboard(monkeypatch)
+    view.is_stt_on = False
+    view._stt_is_starting = True
+    view.set_overlay_peer_contract(
+        _make_overlay_peer_contract(
+            overlay_intent_enabled=True,
+            overlay_state="warning",
+            overlay_status_text="Overlay warning",
+            peer_intent_enabled=True,
+            peer_effective_enabled=False,
+            peer_status_text="Peer starting",
+            peer_state="starting",
+        )
+    )
+
+    view.project_osc_control_state(
+        osc_control_presentation_state(
+            "PuriPuly_Talk",
+            self_capture=False,
+        )
+    )
+    view.project_osc_control_state(
+        osc_control_presentation_state(
+            "PuriPuly_Listen",
+            peer_capture=True,
+        )
+    )
+    view.project_osc_control_state(
+        osc_control_presentation_state(
+            "PuriPuly_Captions",
+            captions=True,
+        )
+    )
+
+    assert view.is_stt_on is False
+    assert view._stt_is_starting is True
+    assert view.peer_button.states[-1] == {
+        "is_on": False,
+        "needs_key": False,
+        "status_text": None,
+        "helper_text": None,
+        "is_starting": True,
+    }
+    assert view.overlay_button.states[-1] == {
+        "is_on": False,
+        "needs_key": True,
+        "status_text": None,
+        "helper_text": None,
+    }
+
+    view._stt_is_starting = False
+    view._stt_showing_warning = True
+    view.project_osc_control_state(
+        osc_control_presentation_state(
+            "PuriPuly_Talk",
+            self_capture=False,
+        )
+    )
+    assert view.is_stt_on is False
+    assert view._stt_showing_warning is True
 
 
 def test_dashboard_managed_auth_pending_restores_local_stt_notice_when_cleared(

--- a/tests/ui/test_presentation_adapter.py
+++ b/tests/ui/test_presentation_adapter.py
@@ -7,6 +7,7 @@ import pytest
 from puripuly_heart.app.ports.ui_models import OverlayPeerPresentationState
 from puripuly_heart.ui.event_bridge import UIEventBridge
 from puripuly_heart.ui.presentation_adapter import FletUiPresentationAdapter
+from tests.helpers.osc_presentation import osc_control_presentation_state
 
 
 def test_presentation_adapter_exposes_only_named_destinations_and_events() -> None:
@@ -274,6 +275,34 @@ def test_presentation_adapter_owns_ui_event_bridge_composition() -> None:
     )
 
     assert isinstance(bridge, UIEventBridge)
+
+
+def test_presentation_adapter_projects_one_snapshot_to_both_ui_surfaces() -> None:
+    events: list[tuple[str, object]] = []
+    dashboard = SimpleNamespace(
+        project_osc_control_state=lambda state: events.append(("dashboard", state))
+    )
+    settings = SimpleNamespace(
+        project_osc_control_state=lambda state: events.append(("settings", state)),
+        load_from_settings=lambda *_args, **_kwargs: events.append(("full-load", None)),
+    )
+    adapter = FletUiPresentationAdapter(
+        SimpleNamespace(
+            view_dashboard=dashboard,
+            view_settings=settings,
+        )
+    )
+    state = osc_control_presentation_state(
+        "PuriPuly_MuteSync",
+        mute_sync=True,
+    )
+
+    adapter.project_osc_control_state(state)
+
+    assert events == [
+        ("dashboard", state),
+        ("settings", state),
+    ]
 
 
 def test_presentation_adapter_preserves_missing_optional_history_destination() -> None:

--- a/tests/ui/test_settings_view_branches.py
+++ b/tests/ui/test_settings_view_branches.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import json
 import logging
 from pathlib import Path
@@ -12,6 +13,8 @@ pytest.importorskip("flet")
 
 from puripuly_heart.core.managed_openrouter_release import TalkTogetherPassStatus
 
+from puripuly_heart.app.ports.ui_models import OscControlPresentationName
+from puripuly_heart.app.services.osc.state_publisher import state_from_settings
 from puripuly_heart.config.audio_host_api import WINDOWS_WASAPI_COMPATIBILITY_HOST_API
 from puripuly_heart.config.settings import (
     LOCAL_LLM_RESERVED_EXTRA_BODY_KEYS,
@@ -35,6 +38,7 @@ from puripuly_heart.config.settings import (
     TranslationFallbackSettings,
     TranslationModel,
     TranslationSettings,
+    materialize_translation_settings,
     to_dict,
 )
 from puripuly_heart.ui import i18n as i18n_module
@@ -47,6 +51,7 @@ from puripuly_heart.ui.overlay_calibration import OverlayCalibration
 from puripuly_heart.ui.theme import COLOR_NEUTRAL_DARK
 from puripuly_heart.ui.views import settings as settings_view
 from tests.helpers.flet_page import attach_dummy_page
+from tests.helpers.osc_presentation import osc_control_presentation_state
 
 
 class DummySecretStore:
@@ -81,6 +86,125 @@ def _make_settings_view(
     if settings is not None:
         view._settings = settings
     return view, store
+
+
+def test_settings_projects_each_osc_owned_field_and_preserves_unrelated_drafts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    baseline = AppSettings()
+    view, _store = _make_settings_view(monkeypatch)
+    view.load_from_settings(baseline, config_path=Path("settings.json"))
+    api_visibility_updates: list[None] = []
+    monkeypatch.setattr(
+        view,
+        "_update_api_visibility",
+        lambda: api_visibility_updates.append(None),
+    )
+    draft = copy.deepcopy(baseline)
+    draft.translation.model = TranslationModel.LOCAL_LLM
+    draft.translation.connection = TranslationConnection.OLLAMA
+    materialize_translation_settings(draft)
+    draft.system_prompt = "unsaved prompt"
+    draft.custom_stt.endpoint = "https://draft.invalid/v1/audio/transcriptions"
+    view._provider_settings_draft = draft
+    view._custom_vocab_tag_editor._input_field.value = "unsubmitted vocabulary"
+    emitted: list[str] = []
+    view.on_settings_changed = lambda _settings: emitted.append("settings")
+    view.on_providers_changed = lambda: emitted.append("providers")
+    canonical = AppSettings()
+    canonical.languages.source_language = "ja"
+    canonical.languages.target_language = "fr"
+    canonical.languages.peer_source_language = "de"
+    canonical.languages.peer_target_language = "ko"
+    canonical.languages.peer_source_mode = "auto"
+    canonical.ui.peer_translation_enabled = True
+    canonical.ui.overlay_enabled = True
+    canonical.osc.vrc_mic_intercept = True
+    canonical.osc.chatbox_include_source = False
+    canonical.provider.stt = STTProviderName.SONIOX
+    canonical.provider.peer_stt = STTProviderName.LOCAL_QWEN_GPU
+    canonical.translation.model = TranslationModel.GEMINI_37_FLASH
+    canonical.translation.connection = TranslationConnection.OFFICIAL_BYOK
+    materialize_translation_settings(canonical)
+    canonical.translation.fallback.enabled = True
+    canonical.translation.fallback.model = TranslationModel.DEEPSEEK_V4_FLASH
+    canonical.translation.fallback.connection = TranslationConnection.OFFICIAL_BYOK
+    canonical_state = state_from_settings(
+        canonical,
+        peer_capture=True,
+        captions=True,
+    )
+
+    view.project_osc_control_state(
+        osc_control_presentation_state(
+            "PuriPuly_MuteSync",
+            settings=canonical,
+            canonical_state=canonical_state,
+        )
+    )
+
+    assert draft.translation.model == TranslationModel.LOCAL_LLM
+    assert draft.translation.connection == TranslationConnection.OLLAMA
+
+    controls: tuple[OscControlPresentationName, ...] = (
+        "PuriPuly_Talk",
+        "PuriPuly_Trans",
+        "PuriPuly_Listen",
+        "PuriPuly_Captions",
+        "PuriPuly_PeerAuto",
+        "PuriPuly_ChatboxSource",
+        "PuriPuly_SelfSrcLang",
+        "PuriPuly_SelfDstLang",
+        "PuriPuly_PeerSrcLang",
+        "PuriPuly_PeerDstLang",
+        "PuriPuly_SelfASR",
+        "PuriPuly_PeerASR",
+        "PuriPuly_Translator",
+        "PuriPuly_Fallback",
+    )
+    for control in controls:
+        view.project_osc_control_state(
+            osc_control_presentation_state(
+                control,
+                settings=canonical,
+                canonical_state=canonical_state,
+            )
+        )
+
+    for projected_settings in (view._settings, view._provider_settings_draft):
+        assert projected_settings is not None
+        assert projected_settings.languages.source_language == "ja"
+        assert projected_settings.languages.target_language == "fr"
+        assert projected_settings.languages.peer_source_language == "de"
+        assert projected_settings.languages.peer_target_language == "ko"
+        assert projected_settings.languages.peer_source_mode == "auto"
+        assert projected_settings.ui.peer_translation_enabled is True
+        assert projected_settings.ui.overlay_enabled is True
+        assert projected_settings.osc.vrc_mic_intercept is True
+        assert projected_settings.osc.chatbox_include_source is False
+        assert projected_settings.provider.stt == STTProviderName.SONIOX
+        assert projected_settings.provider.peer_stt == STTProviderName.LOCAL_QWEN_GPU
+        assert projected_settings.custom_stt.mode == canonical.custom_stt.mode
+        assert projected_settings.custom_stt.compatibility == canonical.custom_stt.compatibility
+        assert projected_settings.provider.llm == canonical.provider.llm
+        assert projected_settings.translation.model == TranslationModel.GEMINI_37_FLASH
+        assert projected_settings.translation.connection == TranslationConnection.OFFICIAL_BYOK
+        assert projected_settings.translation.fallback.enabled is True
+        assert projected_settings.translation.fallback.model == TranslationModel.DEEPSEEK_V4_FLASH
+        assert (
+            projected_settings.translation.fallback.connection
+            == TranslationConnection.OFFICIAL_BYOK
+        )
+    assert view._provider_settings_draft.system_prompt == "unsaved prompt"
+    assert (
+        view._provider_settings_draft.custom_stt.endpoint
+        == "https://draft.invalid/v1/audio/transcriptions"
+    )
+    assert view._custom_vocab_tag_editor._input_field.value == "unsubmitted vocabulary"
+    assert view._vrc_mic_text.content.value == t("settings.vrc_mic.on")
+    assert view._chatbox_source_text.content.value == t("settings.chatbox_source.off")
+    assert len(api_visibility_updates) == 4
+    assert emitted == []
 
 
 def test_cpu_auto_option_is_disabled_until_all_models_are_available(


### PR DESCRIPTION
## What does this PR do?

- Projects accepted VRChat OSC controls from settled canonical state into the relevant dashboard and settings surfaces.
- Keeps projection targeted and non-emitting so unrelated drafts, rejected commands, stale generations, and coalesced updates remain safe.
- Distinguishes local Gemma translation selections bidirectionally: ID 10 selects Gemma 4 E4B CPU, ID 11 selects Gemma 4 E4B GPU, and ID 12 selects Gemma 4 12B.
- Updates the VRChat OSC reference to clarify that avatars only need the parameters they use.

## Related issue

Closes #89
Related to #87

## How was this tested?

- `uv run ruff check .`
- `uv run black --check .`
- Focused OSC protocol, application, router, state publisher, and presentation contract tests.
- All OSC-related Python test modules, including runtime, OSCQuery, UI modal, migration, sender, receiver, and presence coverage.
- Isolated fake/in-memory OSC verification only; VRChat and live external OSC endpoints were not used.

## Notes for reviewers

- Local Gemma OSC IDs were finalized before public distribution: `10 = E4B CPU`, `11 = E4B GPU`, and `12 = 12B`. The 12B option uses its only supported GPU backend internally without adding GPU to its user-facing label.
- Review the canonical-state projection boundary separately from outbound OSC publication; both occur after accepted application settlement but serve different consumers.