### PR TITLE
fix: restore custom HTTP API secrets

### DIFF
--- a/src/puripuly_heart/ui/views/settings.py
+++ b/src/puripuly_heart/ui/views/settings.py
@@ -2691,11 +2691,29 @@ class SettingsView(ft.Column):
     def _sync_http_extension_credentials(self, extension) -> None:
         self._http_extension_secret_fields = {}
         self._http_extension_secret_dirty.clear()
+        secret_values: dict[str, str] = {}
+        if extension is not None and self._settings is not None and self._config_path is not None:
+            try:
+                store = create_secret_store(
+                    self._settings.secrets,
+                    config_path=self._config_path,
+                )
+            except Exception as exc:
+                self._emit_runtime_basic(
+                    f"Failed to load HTTP extension secrets: {exc}",
+                    level=logging.WARNING,
+                )
+            else:
+                secret_values = {
+                    secret.id: store.get(http_extension_secret_key(extension.id, secret.id)) or ""
+                    for secret in extension.secrets
+                }
         controls: list[ft.Control] = []
         if extension is not None:
             for secret in extension.secrets:
                 field = ft.TextField(
                     label=t("settings.http_extension.api_key"),
+                    value=secret_values.get(secret.id, ""),
                     password=True,
                     can_reveal_password=False,
                     border_radius=12,
@@ -2799,11 +2817,13 @@ class SettingsView(ft.Column):
     def _on_http_extension_secret_blur(self, secret_id: str) -> None:
         http_extension_id = self._http_extension_selected_id
         field = self._http_extension_secret_fields.get(secret_id)
-        if not http_extension_id or field is None:
+        if (
+            not http_extension_id
+            or field is None
+            or secret_id not in self._http_extension_secret_dirty
+        ):
             return
         value = (field.value or "").strip()
-        if not value and secret_id not in self._http_extension_secret_dirty:
-            return
         self._http_extension_secret_dirty.discard(secret_id)
         result = self._on_secret_change(
             http_extension_secret_key(http_extension_id, secret_id),

--- a/tests/ui/test_custom_translation_settings.py
+++ b/tests/ui/test_custom_translation_settings.py
@@ -142,8 +142,8 @@ def test_custom_http_card_replaces_llm_detail_surface_and_preserves_switch_back(
     assert pending is not None
     assert pending.translation.http_extension_id == "demo"
     assert set(view._http_extension_secret_fields) == {"api_key"}
-    assert view._http_extension_secret_fields["api_key"].value == ""
-    assert "saved-secret" not in repr(view._http_extension_secret_fields["api_key"])
+    assert view._http_extension_secret_fields["api_key"].value == "saved-secret"
+    assert view._http_extension_secret_fields["api_key"].password is True
     assert not hasattr(view, "_http_extension_request_editor")
 
     view._on_llm_selected(TranslationModel.QWEN_35_PLUS.value)
@@ -172,15 +172,36 @@ def test_custom_http_credentials_use_namespaced_secret_callback_and_reload_isola
     settings.translation.http_extension_id = "demo"
     callbacks: list[tuple[str, str]] = []
     notices: list[str] = []
-    view.on_provider_secret_change = lambda key, value: (callbacks.append((key, value)) or True)
+
+    def save_secret(key: str, value: str) -> bool:
+        callbacks.append((key, value))
+        if value:
+            store.set(key, value)
+        else:
+            store.delete(key)
+        return True
+
+    view.on_provider_secret_change = save_secret
     view.show_snackbar = lambda message, _color: notices.append(message)
     view.load_from_settings(settings, config_path=tmp_path / "settings.json")
 
     field = view._http_extension_secret_fields["api_key"]
+    assert field.value == "saved-secret"
     view._on_http_extension_secret_blur("api_key")
     assert callbacks == []
     field.value = "new-secret"
+    field.on_change(None)
     view._on_http_extension_secret_blur("api_key")
+
+    (tmp_path / "broken.json").write_text("{", encoding="utf-8")
+    changed: list[bool] = []
+    view.on_providers_changed = lambda: changed.append(True)
+    view._on_http_extension_reload(None)
+
+    field = view._http_extension_secret_fields["api_key"]
+    assert field.value == "new-secret"
+    view._on_http_extension_secret_blur("api_key")
+    assert callbacks == [("http_extension.demo.api_key", "new-secret")]
     field.value = ""
     field.on_change(None)
     view._on_http_extension_secret_blur("api_key")
@@ -190,12 +211,6 @@ def test_custom_http_credentials_use_namespaced_secret_callback_and_reload_isola
         ("http_extension.demo.api_key", ""),
     ]
     assert "new-secret" not in repr(settings)
-
-    (tmp_path / "broken.json").write_text("{", encoding="utf-8")
-    changed: list[bool] = []
-    view.on_providers_changed = lambda: changed.append(True)
-    view._on_http_extension_reload(None)
-
     assert [loaded.definition.id for loaded in view._http_extension_snapshot.extensions] == ["demo"]
     assert len(view._http_extension_snapshot.errors) == 1
     assert changed == []


### PR DESCRIPTION
## What does this PR do?

- Restore persisted Custom HTTP API credentials into password fields after client restart and extension JSON reload.
- Avoid rewriting untouched restored credentials while preserving edits and explicit clearing.
- Update UI regression coverage for startup and reload restoration.

## Related issue

Closes #100

## How was this tested?

- `uv run ruff check .`
- `uv run black --check .`
- `uv run pre-commit run --all-files`
- `uv run pytest tests/ui/test_custom_translation_settings.py tests/app/test_canonical_settings_persistence.py::test_http_extension_secret_change_uses_transaction_without_settings_write tests/app/test_ui_provider_runtime_adapter.py::test_active_custom_http_secret_change_rebuilds_runtime_backend tests/core/test_http_extension_translation_backend.py::test_backend_secret_keys_are_unambiguous_for_dotted_ids` (9 passed)
- Windows multi-process smoke test using the production encrypted secret store: restart and JSON reload both restored the credential in a password field.

## Notes for reviewers

Credentials remain outside AppSettings and use the existing namespaced SecretStore keys. Restored fields remain password-masked.