### PR TITLE
Wire Qwen Audio 3.0 peer language auto-detection and language hints

### DIFF
--- a/src/puripuly_heart/app/wiring/wiring_stt_factory.py
+++ b/src/puripuly_heart/app/wiring/wiring_stt_factory.py
@@ -244,9 +244,15 @@ def peer_stt_runtime_intent_from_vnext(settings: AppSettingsVNext) -> STTRuntime
     provider, qwen_asr_model = _qwen_runtime_provider_and_model(provider, intent.stt.qwen_asr.model)
     automatic = intent.languages.peer_source_mode == "auto"
     automatic_soniox = provider == STT_PROVIDER_SONIOX and automatic
+    automatic_qwen_audio = (
+        provider == STT_PROVIDER_QWEN_ASR
+        and qwen_asr_model == QWEN_ASR_STT_MODEL_AUDIO_STREAMING
+        and automatic
+    )
     source_language = intent.languages.peer_source_language or intent.languages.source_language
     language_hints = None
     language_hints_strict = False
+    qwen_audio_language_hints = None
     if provider == STT_PROVIDER_SONIOX:
         from puripuly_heart.core.language import get_soniox_language_hints
 
@@ -261,6 +267,12 @@ def peer_stt_runtime_intent_from_vnext(settings: AppSettingsVNext) -> STTRuntime
             language_hints = mapped_language_hints or None
         else:
             language_hints = tuple(get_soniox_language_hints(source_language))
+    if automatic_qwen_audio:
+        from puripuly_heart.core.language import qwen_audio_asr_language_hints
+
+        qwen_audio_language_hints = qwen_audio_asr_language_hints(
+            intent.languages.peer_expected_languages
+        )
     custom_mode, custom_compatibility = custom_stt_selection_for_provider(
         provider,
         stored_mode=intent.stt.custom.mode,
@@ -296,6 +308,7 @@ def peer_stt_runtime_intent_from_vnext(settings: AppSettingsVNext) -> STTRuntime
         soniox_enable_language_identification=automatic_soniox,
         soniox_language_hints=language_hints,
         soniox_language_hints_strict=language_hints_strict,
+        qwen_audio_language_hints=qwen_audio_language_hints,
         custom_stt_mode=custom_mode,
         custom_stt_compatibility=custom_compatibility,
         custom_stt_endpoint=intent.stt.custom.endpoint,
@@ -668,6 +681,18 @@ def _qwen_asr_endpoint_for_resolved_config(config: ResolvedSTTConfig) -> str:
     return _qwen_asr_endpoint_for_region(config.region, config.model)
 
 
+def _resolved_qwen_audio_language_hints(config: ResolvedSTTConfig) -> tuple[str, ...]:
+    from puripuly_heart.core.language import get_qwen_audio_asr_language
+    from puripuly_heart.providers.stt.qwen_audio import QWEN_AUDIO_LANGUAGE_HINTS_LIMIT
+
+    if config.source_mode == "auto":
+        value = config.provider_options.get("language_hints")
+        if isinstance(value, tuple) and all(isinstance(hint, str) for hint in value):
+            return value[:QWEN_AUDIO_LANGUAGE_HINTS_LIMIT]
+        return ()
+    return (get_qwen_audio_asr_language(config.source_language),)
+
+
 def create_stt_backend_from_resolved_config(
     config: ResolvedSTTConfig,
     *,
@@ -747,14 +772,13 @@ def create_stt_backend_from_resolved_config(
         model = config.model or "qwen3-asr-flash-realtime"
         api_key = _qwen_api_key_for_resolved_credential(config.credential, secrets=secrets)
         if model == QWEN_ASR_STT_MODEL_AUDIO_STREAMING:
-            from puripuly_heart.core.language import get_qwen_audio_asr_language
             from puripuly_heart.providers.stt.qwen_audio import QwenAudioStreamingSTTBackend
 
             return QwenAudioStreamingSTTBackend(
                 api_key=api_key,
                 model=model,
                 endpoint=_qwen_asr_endpoint_for_resolved_config(config),
-                language=get_qwen_audio_asr_language(config.source_language),
+                language_hints=_resolved_qwen_audio_language_hints(config),
                 sample_rate_hz=config.sample_rate_hz,
                 hotwords=keyterms,
             )

--- a/src/puripuly_heart/composition/application_runtime.py
+++ b/src/puripuly_heart/composition/application_runtime.py
@@ -219,8 +219,10 @@ from puripuly_heart.config.provider_values import (
     QwenLLMModel,
     QwenRegion,
     STTProviderName,
+    qwen_cloud_stt_model_for_provider,
 )
 from puripuly_heart.config.resolved import OVERLAY_TARGET_STEAMVR
+from puripuly_heart.config.runtime_resolution import stt_supports_peer_auto_detection
 from puripuly_heart.config.settings_vnext.schema import AppSettingsVNext
 from puripuly_heart.config.translation_values import TranslationModel
 from puripuly_heart.core.clipboard.watcher import create_clipboard_watcher
@@ -1187,11 +1189,12 @@ def compose_application_runtime(
             recent_source_languages=languages.recent_source_languages,
             recent_target_languages=languages.recent_target_languages,
             peer_auto_detect_available=(
-                canonical.intent.peer_stt.provider
-                in {
-                    STTProviderName.SONIOX.value,
-                    STTProviderName.LOCAL_QWEN_GPU.value,
-                }
+                stt_supports_peer_auto_detection(
+                    canonical.intent.peer_stt.provider,
+                    qwen_asr_model=qwen_cloud_stt_model_for_provider(
+                        canonical.intent.peer_stt.provider
+                    ),
+                )
             ),
         )
         loaded = require_projection().render(settings.canonical)
@@ -1337,11 +1340,7 @@ def compose_application_runtime(
                 ),
             )
         if (
-            merged.intent.peer_stt.provider
-            not in {
-                STTProviderName.SONIOX.value,
-                STTProviderName.LOCAL_QWEN_GPU.value,
-            }
+            not stt_supports_peer_auto_detection(merged.intent.peer_stt.provider)
             and merged.intent.languages.peer_source_mode == "auto"
         ):
             merged = replace(

--- a/src/puripuly_heart/config/runtime_resolution.py
+++ b/src/puripuly_heart/config/runtime_resolution.py
@@ -227,6 +227,7 @@ STT_PROVIDER_LOCAL_QWEN: Final = "local_qwen"
 STT_PROVIDER_LOCAL_QWEN_GPU: Final = "local_qwen_gpu"
 STT_PROVIDER_DEEPGRAM: Final = "deepgram"
 STT_PROVIDER_QWEN_ASR: Final = "qwen_asr"
+STT_PROVIDER_QWEN_AUDIO: Final = "qwen_audio"
 STT_PROVIDER_SONIOX: Final = "soniox"
 STT_PROVIDER_CUSTOM: Final = "custom"
 STT_PROVIDER_CUSTOM_OFFLINE: Final = "custom_offline"
@@ -770,6 +771,7 @@ class STTRuntimeIntent:
     soniox_enable_language_identification: bool = False
     soniox_language_hints: tuple[str, ...] | None = None
     soniox_language_hints_strict: bool = False
+    qwen_audio_language_hints: tuple[str, ...] | None = None
     custom_stt_mode: str = "offline"
     custom_stt_compatibility: str = "openai_transcription"
     custom_stt_endpoint: str = ""
@@ -800,7 +802,9 @@ class STTRuntimeIntent:
             allowed=("manual", "auto"),
             default="manual",
         )
-        if channel != RUNTIME_CHANNEL_PEER or provider not in PEER_AUTO_DETECTION_STT_PROVIDERS:
+        if channel != RUNTIME_CHANNEL_PEER or not stt_supports_peer_auto_detection(
+            provider, qwen_asr_model=self.qwen_asr_model
+        ):
             source_mode = "manual"
         qwen_region = _normalize_allowed(
             self.qwen_region,
@@ -863,6 +867,19 @@ class STTRuntimeIntent:
                     if str(language).strip()
                 )
                 if self.soniox_language_hints is not None
+                else None
+            ),
+        )
+        object.__setattr__(
+            self,
+            "qwen_audio_language_hints",
+            (
+                tuple(
+                    str(hint).strip()
+                    for hint in self.qwen_audio_language_hints
+                    if str(hint).strip()
+                )
+                if self.qwen_audio_language_hints is not None
                 else None
             ),
         )
@@ -1230,6 +1247,16 @@ def _resolved_direct_provider_target(
     )
 
 
+def stt_supports_peer_auto_detection(provider: str, *, qwen_asr_model: str | None = None) -> bool:
+    if provider in PEER_AUTO_DETECTION_STT_PROVIDERS:
+        return True
+    if provider == STT_PROVIDER_QWEN_AUDIO:
+        return True
+    if provider == STT_PROVIDER_QWEN_ASR:
+        return qwen_asr_model == QWEN_ASR_STT_MODEL_AUDIO_STREAMING
+    return False
+
+
 def resolve_stt_config(intent: STTRuntimeIntent) -> ResolvedSTTConfig:
     provider = intent.provider
     model: str | None = None
@@ -1251,6 +1278,9 @@ def resolve_stt_config(intent: STTRuntimeIntent) -> ResolvedSTTConfig:
             CREDENTIAL_SOURCE_SECRET_STORE,
             _qwen_credential_reference(intent.qwen_region),
         )
+        if model == QWEN_ASR_STT_MODEL_AUDIO_STREAMING and intent.source_mode == "auto":
+            hints = intent.qwen_audio_language_hints
+            provider_options = {"language_hints": hints if hints is not None else ()}
     elif provider == STT_PROVIDER_SONIOX:
         model = intent.soniox_model
         endpoint = intent.soniox_endpoint
@@ -1722,4 +1752,5 @@ __all__ = [
     "resolve_overlay_config",
     "resolve_llm_config",
     "resolve_stt_config",
+    "stt_supports_peer_auto_detection",
 ]

--- a/src/puripuly_heart/core/language.py
+++ b/src/puripuly_heart/core/language.py
@@ -192,6 +192,31 @@ def get_qwen_audio_asr_language(code: str) -> str:
     return _language_from_map(code, _QWEN_AUDIO_ASR_LANGUAGE_MAP)
 
 
+def qwen_audio_asr_language_hint(code: str) -> str | None:
+    if not is_qwen_audio_asr_supported(code):
+        return None
+    return _language_from_map(code, _QWEN_AUDIO_ASR_LANGUAGE_MAP)
+
+
+def qwen_audio_asr_language_hints(
+    codes: Sequence[str],
+    *,
+    limit: int | None = None,
+) -> tuple[str, ...]:
+    hints: list[str] = []
+    for code in codes:
+        normalized = str(code).strip()
+        if not normalized:
+            continue
+        if limit is not None and len(hints) >= limit:
+            break
+        mapped = qwen_audio_asr_language_hint(normalized)
+        if mapped is None or mapped in hints:
+            continue
+        hints.append(mapped)
+    return tuple(hints)
+
+
 def is_qwen3_asr_supported(code: str) -> bool:
     if code in _QWEN_ASR_LANGUAGE_MAP:
         return True

--- a/src/puripuly_heart/providers/stt/qwen_audio.py
+++ b/src/puripuly_heart/providers/stt/qwen_audio.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 QWEN_AUDIO_MODEL = "qwen-audio-3.0-asr-flash-streaming"
 QWEN_AUDIO_DEFAULT_ENDPOINT = "wss://dashscope.aliyuncs.com/api-ws/v1/inference"
 QWEN_AUDIO_DEFAULT_HOTWORD_WEIGHT = 4
+QWEN_AUDIO_LANGUAGE_HINTS_LIMIT = 4
 
 
 class QwenAudioSessionState(str, Enum):
@@ -108,7 +109,7 @@ def _join_sentences(sentences: Sequence[str]) -> str:
 @dataclass(slots=True)
 class QwenAudioStreamingSTTBackend(STTBackend):
     api_key: str
-    language: str
+    language_hints: tuple[str, ...] = ()
     model: str = QWEN_AUDIO_MODEL
     endpoint: str = QWEN_AUDIO_DEFAULT_ENDPOINT
     sample_rate_hz: int = 16000
@@ -125,8 +126,8 @@ class QwenAudioStreamingSTTBackend(STTBackend):
             raise ValueError("sample_rate_hz must be 8000 or 16000")
         if not self.api_key:
             raise ValueError("api_key must be non-empty")
-        if not self.language:
-            raise ValueError("language must be non-empty")
+        if any(not hint for hint in self.language_hints):
+            raise ValueError("language hints must be non-empty")
         if not self.endpoint:
             raise ValueError("endpoint must be non-empty")
         for name, value in (
@@ -139,7 +140,7 @@ class QwenAudioStreamingSTTBackend(STTBackend):
                 raise ValueError(f"{name} must be > 0")
         session = _QwenAudioSession(
             api_key=self.api_key,
-            language=self.language,
+            language_hints=self.language_hints,
             model=self.model,
             endpoint=self.endpoint,
             sample_rate_hz=self.sample_rate_hz,
@@ -187,7 +188,7 @@ class _QwenAudioBoundary:
 @dataclass(slots=True)
 class _QwenAudioSession(STTBackendSession):
     api_key: str
-    language: str
+    language_hints: tuple[str, ...]
     model: str
     endpoint: str
     sample_rate_hz: int
@@ -311,12 +312,13 @@ class _QwenAudioSession(STTBackendSession):
         parameters: dict[str, object] = {
             "format": "pcm",
             "sample_rate": self.sample_rate_hz,
-            "language_hints": [self.language],
             "semantic_punctuation_enabled": False,
             "max_sentence_silence": 6000,
             "multi_threshold_mode_enabled": False,
             "heartbeat": True,
         }
+        if self.language_hints:
+            parameters["language_hints"] = list(self.language_hints)
         vocabulary = self._vocabulary()
         if vocabulary:
             parameters["vocabulary"] = vocabulary

--- a/src/puripuly_heart/ui/views/dashboard.py
+++ b/src/puripuly_heart/ui/views/dashboard.py
@@ -9,6 +9,7 @@ from puripuly_heart.app.ports.ui_models import (
     ManagedGemmaNoticeAction,
     OscControlPresentationState,
 )
+from puripuly_heart.config.runtime_resolution import stt_supports_peer_auto_detection
 from puripuly_heart.core.language import get_all_language_options
 from puripuly_heart.ui.components.display_card import DisplayCard
 from puripuly_heart.ui.components.language_card import LanguageCard
@@ -596,7 +597,7 @@ class DashboardView(ft.Column):
                 state.self_secondary_target_language,
             )
         elif control == "PuriPuly_PeerASR":
-            self.set_peer_auto_detect_available(state.peer_asr in {"soniox", "local_qwen_gpu"})
+            self.set_peer_auto_detect_available(stt_supports_peer_auto_detection(state.peer_asr))
         elif control in {"PuriPuly_Listen", "PuriPuly_Captions"}:
             capture = capture_presentation_from_contract(self._overlay_peer_contract)
             if control == "PuriPuly_Listen":

--- a/src/puripuly_heart/ui/views/settings.py
+++ b/src/puripuly_heart/ui/views/settings.py
@@ -4326,7 +4326,10 @@ class SettingsView(ft.Column):
         self._soniox_key.visible = STTProviderName.SONIOX in active_stt_providers
         peer_auto_languages_card = getattr(self, "_peer_auto_languages_card", None)
         if peer_auto_languages_card is not None:
-            peer_auto_languages_card.visible = peer_stt == STTProviderName.SONIOX
+            peer_auto_languages_card.visible = peer_stt in {
+                STTProviderName.SONIOX,
+                STTProviderName.QWEN_AUDIO,
+            }
             self._sync_peer_auto_languages_editor()
             if is_control_mounted(self):
                 try:

--- a/tests/app/test_wiring_providers.py
+++ b/tests/app/test_wiring_providers.py
@@ -2434,6 +2434,166 @@ def test_mixed_qwen_cloud_providers_resolve_independent_models() -> None:
     assert peer_intent.qwen_asr_model == "qwen-audio-3.0-asr-flash-streaming"
 
 
+def test_qwen_audio_auto_mode_survives_peer_runtime_normalization() -> None:
+    settings = _vnext(
+        peer_stt_provider="qwen_audio",
+        peer_source_mode="auto",
+        peer_expected_languages=["ja", "zh-TW"],
+    )
+
+    intent = peer_stt_runtime_intent_from_vnext(settings)
+
+    assert intent.provider == "qwen_asr"
+    assert intent.qwen_asr_model == "qwen-audio-3.0-asr-flash-streaming"
+    assert intent.source_mode == "auto"
+    assert intent.qwen_audio_language_hints == ("ja", "zh")
+
+
+def test_non_audio_qwen_asr_runtime_does_not_inherit_auto_detection() -> None:
+    settings = _vnext(
+        peer_stt_provider="qwen_asr",
+        qwen_asr_model="qwen3-asr-flash-realtime",
+        peer_source_mode="auto",
+        peer_expected_languages=["ja"],
+    )
+
+    intent = peer_stt_runtime_intent_from_vnext(settings)
+
+    assert intent.source_mode == "manual"
+    assert intent.qwen_audio_language_hints is None
+    assert intent.soniox_language_hints is None
+
+
+def test_qwen_audio_manual_mode_keeps_single_hint_contract() -> None:
+    settings = _vnext(
+        peer_stt_provider="qwen_audio",
+        peer_source_mode="manual",
+        peer_source_language="ja",
+        peer_expected_languages=["ko", "ja"],
+    )
+
+    resolved = resolve_peer_stt_runtime_config(settings)
+
+    assert resolved.source_mode == "manual"
+    assert resolved.provider_options == {}
+
+
+def test_qwen_audio_auto_without_expected_languages_omits_hints() -> None:
+    settings = _vnext(
+        peer_stt_provider="qwen_audio",
+        peer_source_mode="auto",
+        peer_expected_languages=[],
+    )
+
+    resolved = resolve_peer_stt_runtime_config(settings)
+
+    assert resolved.source_mode == "auto"
+    assert resolved.provider_options["language_hints"] == ()
+
+
+def test_qwen_audio_auto_sends_ordered_mapped_deduped_hints() -> None:
+    settings = _vnext(
+        peer_stt_provider="qwen_audio",
+        peer_source_mode="auto",
+        peer_expected_languages=["ko", "ja", "zh-CN", "zh-TW", "en"],
+    )
+
+    resolved = resolve_peer_stt_runtime_config(settings)
+
+    assert resolved.source_mode == "auto"
+    assert resolved.provider_options["language_hints"] == ("ko", "ja", "zh", "en")
+
+
+def test_qwen_audio_auto_drops_unsupported_expected_languages() -> None:
+    settings = _vnext(
+        peer_stt_provider="qwen_audio",
+        peer_source_mode="auto",
+        peer_expected_languages=["ko", "xx", "et", "ja"],
+    )
+
+    resolved = resolve_peer_stt_runtime_config(settings)
+
+    assert resolved.provider_options["language_hints"] == ("ko", "ja")
+
+
+def test_qwen_audio_provider_handoff_caps_hints_at_four() -> None:
+    from puripuly_heart.providers.stt.qwen_audio import QwenAudioStreamingSTTBackend
+
+    settings = _vnext(
+        peer_stt_provider="qwen_audio",
+        peer_source_mode="auto",
+        peer_expected_languages=["ko", "ja", "zh-CN", "zh-TW", "en", "fr"],
+    )
+    secrets = InMemorySecretStore()
+    secrets.set("alibaba_api_key_beijing", "k-audio")
+
+    backend = create_peer_stt_backend(settings, secrets=secrets)
+
+    assert isinstance(backend, QwenAudioStreamingSTTBackend)
+    assert backend.language_hints == ("ko", "ja", "zh", "en")
+
+
+def test_qwen_audio_manual_handoff_sends_single_mapped_hint() -> None:
+    from puripuly_heart.providers.stt.qwen_audio import QwenAudioStreamingSTTBackend
+
+    settings = _vnext(
+        peer_stt_provider="qwen_audio",
+        peer_source_mode="manual",
+        peer_source_language="ja",
+    )
+    secrets = InMemorySecretStore()
+    secrets.set("alibaba_api_key_beijing", "k-audio")
+
+    backend = create_peer_stt_backend(settings, secrets=secrets)
+
+    assert isinstance(backend, QwenAudioStreamingSTTBackend)
+    assert backend.language_hints == ("ja",)
+
+
+def test_peer_expected_languages_remain_untruncated_for_qwen_audio() -> None:
+    settings = _vnext(
+        peer_stt_provider="qwen_audio",
+        peer_source_mode="auto",
+        peer_expected_languages=["ko", "ja", "zh-CN", "zh-TW", "en", "fr"],
+    )
+
+    _ = resolve_peer_stt_runtime_config(settings)
+
+    assert settings.intent.languages.peer_expected_languages == [
+        "ko",
+        "ja",
+        "zh-CN",
+        "zh-TW",
+        "en",
+        "fr",
+    ]
+
+
+def test_peer_stt_provider_signature_tracks_qwen_audio_language_hints() -> None:
+    auto_settings = _vnext(
+        peer_stt_provider="qwen_audio",
+        peer_source_mode="auto",
+        peer_expected_languages=["ko", "ja"],
+    )
+    other_hints = _vnext(
+        peer_stt_provider="qwen_audio",
+        peer_source_mode="auto",
+        peer_expected_languages=["ko", "en"],
+    )
+    manual_settings = _vnext(
+        peer_stt_provider="qwen_audio",
+        peer_source_mode="manual",
+        peer_source_language="ja",
+    )
+
+    assert build_peer_stt_provider_signature_from_vnext(
+        auto_settings
+    ) != build_peer_stt_provider_signature_from_vnext(other_hints)
+    assert build_peer_stt_provider_signature_from_vnext(
+        auto_settings
+    ) != build_peer_stt_provider_signature_from_vnext(manual_settings)
+
+
 def test_create_peer_stt_backend_uses_peer_local_qwen_provider_and_fixed_sample_rate() -> None:
     settings = _vnext(peer_stt_provider="local_qwen")
     secrets = InMemorySecretStore()

--- a/tests/config/test_runtime_resolution.py
+++ b/tests/config/test_runtime_resolution.py
@@ -275,6 +275,89 @@ def test_peer_auto_source_mode_requires_provider_capability() -> None:
     assert self_gpu.source_mode == "manual"
 
 
+def test_qwen_audio_runtime_keeps_auto_mode_while_realtime_does_not() -> None:
+    runtime_resolution = _runtime_resolution_module()
+
+    audio = runtime_resolution.resolve_stt_config(
+        runtime_resolution.STTRuntimeIntent(
+            channel="peer",
+            provider=runtime_resolution.STT_PROVIDER_QWEN_ASR,
+            qwen_asr_model=runtime_resolution.QWEN_ASR_STT_MODEL_AUDIO_STREAMING,
+            source_mode="auto",
+        )
+    )
+    realtime = runtime_resolution.resolve_stt_config(
+        runtime_resolution.STTRuntimeIntent(
+            channel="peer",
+            provider=runtime_resolution.STT_PROVIDER_QWEN_ASR,
+            qwen_asr_model=runtime_resolution.QWEN_ASR_STT_MODEL_REALTIME,
+            source_mode="auto",
+        )
+    )
+    self_audio = runtime_resolution.resolve_stt_config(
+        runtime_resolution.STTRuntimeIntent(
+            channel="self",
+            provider=runtime_resolution.STT_PROVIDER_QWEN_ASR,
+            qwen_asr_model=runtime_resolution.QWEN_ASR_STT_MODEL_AUDIO_STREAMING,
+            source_mode="auto",
+        )
+    )
+
+    assert audio.source_mode == "auto"
+    assert realtime.source_mode == "manual"
+    assert self_audio.source_mode == "manual"
+
+
+def test_qwen_audio_auto_resolution_propagates_expected_language_hints() -> None:
+    runtime_resolution = _runtime_resolution_module()
+
+    auto = runtime_resolution.resolve_stt_config(
+        runtime_resolution.STTRuntimeIntent(
+            channel="peer",
+            provider=runtime_resolution.STT_PROVIDER_QWEN_ASR,
+            qwen_asr_model=runtime_resolution.QWEN_ASR_STT_MODEL_AUDIO_STREAMING,
+            source_mode="auto",
+            qwen_audio_language_hints=("ja", "ja-JP", "zh"),
+        )
+    )
+    no_hints = runtime_resolution.resolve_stt_config(
+        runtime_resolution.STTRuntimeIntent(
+            channel="peer",
+            provider=runtime_resolution.STT_PROVIDER_QWEN_ASR,
+            qwen_asr_model=runtime_resolution.QWEN_ASR_STT_MODEL_AUDIO_STREAMING,
+            source_mode="auto",
+        )
+    )
+    manual = runtime_resolution.resolve_stt_config(
+        runtime_resolution.STTRuntimeIntent(
+            channel="peer",
+            provider=runtime_resolution.STT_PROVIDER_QWEN_ASR,
+            qwen_asr_model=runtime_resolution.QWEN_ASR_STT_MODEL_AUDIO_STREAMING,
+            source_mode="manual",
+            qwen_audio_language_hints=("ja",),
+        )
+    )
+
+    assert auto.provider_options["language_hints"] == ("ja", "ja-JP", "zh")
+    assert no_hints.provider_options["language_hints"] == ()
+    assert manual.provider_options == {}
+
+
+def test_stt_supports_peer_auto_detection_is_model_aware_for_qwen() -> None:
+    runtime_resolution = _runtime_resolution_module()
+
+    assert runtime_resolution.stt_supports_peer_auto_detection("soniox")
+    assert runtime_resolution.stt_supports_peer_auto_detection("local_qwen_gpu")
+    assert runtime_resolution.stt_supports_peer_auto_detection("qwen_audio")
+    assert runtime_resolution.stt_supports_peer_auto_detection(
+        "qwen_asr", qwen_asr_model="qwen-audio-3.0-asr-flash-streaming"
+    )
+    assert not runtime_resolution.stt_supports_peer_auto_detection(
+        "qwen_asr", qwen_asr_model="qwen3-asr-flash-realtime"
+    )
+    assert not runtime_resolution.stt_supports_peer_auto_detection("deepgram")
+
+
 def test_default_peer_stt_runtime_intent_uses_desktop_peer_vad_defaults() -> None:
     runtime_resolution = _runtime_resolution_module()
     resolved = _resolved_module()

--- a/tests/core/test_language.py
+++ b/tests/core/test_language.py
@@ -49,6 +49,28 @@ def test_qwen_asr_language_normalization() -> None:
     assert get_qwen_asr_language("ko-KR") == "ko"
 
 
+def test_qwen_audio_hint_mapping_drops_unsupported_dedupes_and_limits() -> None:
+    from puripuly_heart.core.language import qwen_audio_asr_language_hints
+
+    assert qwen_audio_asr_language_hints(["ko", "ja", "zh-CN", "zh-TW", "en"]) == (
+        "ko",
+        "ja",
+        "zh",
+        "en",
+    )
+    assert qwen_audio_asr_language_hints(["ko", "xx", "et"]) == ("ko",)
+    assert qwen_audio_asr_language_hints(["ja", "ja", "ja-JP"]) == ("ja",)
+    assert qwen_audio_asr_language_hints(["ja", "ko"], limit=0) == ()
+    assert qwen_audio_asr_language_hints(["ko", "ja", "zh-CN", "zh-TW", "en", "fr"], limit=4) == (
+        "ko",
+        "ja",
+        "zh",
+        "en",
+    )
+    assert qwen_audio_asr_language_hints([]) == ()
+    assert qwen_audio_asr_language_hints(["xx"]) == ()
+
+
 def test_local_qwen_language_hint_normalization_is_conservative() -> None:
     assert hasattr(language_module, "get_local_qwen_language_hint")
 

--- a/tests/core/test_stt_controller.py
+++ b/tests/core/test_stt_controller.py
@@ -2838,7 +2838,7 @@ async def test_qwen_audio_bridging_reset_discards_old_active_boundary() -> None:
 
     backend = QwenAudioStreamingSTTBackend(
         api_key="test-key",
-        language="ko",
+        language_hints=("ko",),
         model=QWEN_AUDIO_MODEL,
         websocket_factory=connect,
         connect_timeout_s=1,
@@ -2961,7 +2961,7 @@ async def test_qwen_audio_bridge_retires_pending_old_boundary_before_new_final()
 
     backend = QwenAudioStreamingSTTBackend(
         api_key="test-key",
-        language="ko",
+        language_hints=("ko",),
         model=QWEN_AUDIO_MODEL,
         websocket_factory=connect,
         connect_timeout_s=1,
@@ -3031,7 +3031,7 @@ async def test_qwen_audio_bridge_cutover_captures_boundary_during_delayed_open()
 
     backend = QwenAudioStreamingSTTBackend(
         api_key="test-key",
-        language="ko",
+        language_hints=("ko",),
         model=QWEN_AUDIO_MODEL,
         websocket_factory=connect,
         connect_timeout_s=1,

--- a/tests/providers/test_qwen_audio.py
+++ b/tests/providers/test_qwen_audio.py
@@ -59,6 +59,7 @@ async def open_fake(
     task_start_timeout_s: float = 1,
     task_finish_timeout_s: float = 0.2,
     send_timeout_s: float = 5,
+    language_hints: tuple[str, ...] = ("ko",),
 ) -> tuple[QwenAudioStreamingSTTBackend, object, FakeWebSocket, str]:
     socket = FakeWebSocket()
 
@@ -67,7 +68,7 @@ async def open_fake(
 
     backend = QwenAudioStreamingSTTBackend(
         api_key="test-key",
-        language="ko",
+        language_hints=language_hints,
         hotwords=hotwords,
         websocket_factory=connect,
         connect_timeout_s=1,
@@ -269,6 +270,45 @@ def test_qwen_audio_backend_contract_constants() -> None:
     assert resolved.region == "singapore"
 
 
+def _run_task_parameters(socket: FakeWebSocket, index: int = 0) -> dict:
+    payload = json.loads(socket.sent[index])
+    assert payload["header"]["action"] == "run-task"
+    return payload["payload"]["parameters"]
+
+
+@pytest.mark.asyncio
+async def test_auto_detect_without_hints_omits_language_hints_key() -> None:
+    _, session, socket, _ = await open_fake(language_hints=())
+    parameters = _run_task_parameters(socket)
+    assert "language_hints" not in parameters
+    await session.abort_for_toggle_off()
+
+
+@pytest.mark.asyncio
+async def test_manual_language_sends_single_mapped_hint_in_payload() -> None:
+    _, session, socket, _ = await open_fake(language_hints=("ja",))
+    assert _run_task_parameters(socket)["language_hints"] == ["ja"]
+    await session.abort_for_toggle_off()
+
+
+@pytest.mark.asyncio
+async def test_constrained_auto_detect_sends_ordered_hints_in_payload() -> None:
+    _, session, socket, _ = await open_fake(language_hints=("ko", "ja", "zh", "en"))
+    assert _run_task_parameters(socket)["language_hints"] == ["ko", "ja", "zh", "en"]
+    await session.abort_for_toggle_off()
+
+
+@pytest.mark.asyncio
+async def test_repeated_tasks_reuse_the_same_language_hints() -> None:
+    _, session, socket, first_id = await open_fake(language_hints=("ko", "ja"))
+    await session.on_speech_end()
+    await socket.push({"header": {"event": "task-finished", "task_id": first_id}})
+    await wait_for_condition(lambda: len(socket.sent) >= 3)
+    assert _run_task_parameters(socket, 0)["language_hints"] == ["ko", "ja"]
+    assert _run_task_parameters(socket, 2)["language_hints"] == ["ko", "ja"]
+    await session.abort_for_toggle_off()
+
+
 @pytest.mark.asyncio
 async def test_task_finish_timeout_emits_empty_boundary_then_failure() -> None:
     _, session, socket, _ = await open_fake()
@@ -325,7 +365,7 @@ def test_factory_selects_qwen_audio_protocol_and_source_terms() -> None:
     secrets.set("alibaba_api_key_singapore", "test-key")
     backend = create_stt_backend_from_resolved_config(resolved, secrets=secrets)
     assert isinstance(backend, QwenAudioStreamingSTTBackend)
-    assert backend.language == "tl"
+    assert backend.language_hints == ("tl",)
     assert backend.endpoint.endswith("/api-ws/v1/inference")
     assert tuple(backend.hotwords) == ("PuriPuly", "Qwen")
 
@@ -448,7 +488,7 @@ async def test_task_start_timeout_is_terminal() -> None:
 
     backend = QwenAudioStreamingSTTBackend(
         api_key="test-key",
-        language="ko",
+        language_hints=("ko",),
         websocket_factory=connect,
         connect_timeout_s=1,
         task_start_timeout_s=0.01,
@@ -466,7 +506,7 @@ async def test_initial_connection_failure_is_terminal() -> None:
 
     backend = QwenAudioStreamingSTTBackend(
         api_key="test-key",
-        language="ko",
+        language_hints=("ko",),
         websocket_factory=connect,
         connect_timeout_s=1,
         task_start_timeout_s=1,

--- a/tests/ui/test_dashboard_view_branches.py
+++ b/tests/ui/test_dashboard_view_branches.py
@@ -615,6 +615,49 @@ def test_dashboard_projects_osc_state_without_emitting_intents(
     assert emitted == []
 
 
+def test_dashboard_peer_auto_detect_availability_tracks_qwen_audio_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    view = _make_dashboard(monkeypatch)
+    baseline = AppSettingsVNext()
+    qwen_audio_settings = replace(
+        baseline,
+        intent=replace(
+            baseline.intent,
+            peer_stt=replace(
+                baseline.intent.peer_stt,
+                provider=STTProviderName.QWEN_AUDIO.value,
+            ),
+        ),
+    )
+    realtime_settings = replace(
+        baseline,
+        intent=replace(
+            baseline.intent,
+            peer_stt=replace(
+                baseline.intent.peer_stt,
+                provider=STTProviderName.QWEN_ASR.value,
+            ),
+        ),
+    )
+
+    view.project_osc_control_state(
+        osc_control_presentation_state(
+            "PuriPuly_PeerASR",
+            settings=qwen_audio_settings,
+        )
+    )
+    assert view._peer_auto_detect_available is True
+
+    view.project_osc_control_state(
+        osc_control_presentation_state(
+            "PuriPuly_PeerASR",
+            settings=realtime_settings,
+        )
+    )
+    assert view._peer_auto_detect_available is False
+
+
 def test_dashboard_osc_projection_preserves_rich_peer_and_overlay_states(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/ui/test_settings_view_branches.py
+++ b/tests/ui/test_settings_view_branches.py
@@ -4387,6 +4387,21 @@ def test_peer_auto_detection_languages_card_is_visible_only_for_peer_soniox(
     assert view._peer_auto_languages_editor._terms == ["ja"]
 
 
+def test_peer_auto_detection_languages_card_is_visible_for_peer_qwen_audio(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = AppSettingsVNext()
+    view, _ = _make_settings_view(monkeypatch, settings=settings)
+
+    settings = _vnext(settings, peer_stt_provider=STTProviderName.QWEN_AUDIO)
+    settings = _vnext(settings, peer_expected_languages=["ja", "zh-TW"])
+    view._settings = settings
+    view._update_api_visibility()
+
+    assert view._peer_auto_languages_card.visible is True
+    assert view._peer_auto_languages_editor._terms == ["ja", "zh-TW"]
+
+
 def test_overlay_display_toggles_update_persistent_settings(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Probe result: Qwen Audio auto-detection raw response

Implementation order step 1 (raw-response probe before wiring language propagation) is done.

### Setup

- Model: `qwen-audio-3.0-asr-flash-streaming`
- Endpoint: `wss://dashscope.aliyuncs.com/api-ws/v1/inference` (beijing)
- Payload: `language_hints` **omitted entirely** (full auto-detection), otherwise the same parameters as the backend sends (`format: pcm`, `sample_rate: 16000`, `semantic_punctuation_enabled: false`, `max_sentence_silence: 6000`, `multi_threshold_mode_enabled: false`, `heartbeat: true`)
- Utterances: Korean ("안녕하세요, 오늘 날씨가 참 좋네요. 함께 산책하러 갈까요?") and English ("Hello there, the weather is really nice today. Shall we go for a walk together?"), 16 kHz mono PCM
- Note: Japanese utterance was skipped by owner direction (2026-09-02), so the probe covers ko + en only.

### Result

Both utterances transcribed correctly under full auto-detection — omitting `language_hints` works as expected.

**No detected-language metadata is returned anywhere.** The complete raw `result-generated` payloads contain none of `language`, `lang`, `language_code`, `detected_language`, or `locale`. `payload.output` only ever carries `request_id`, `sentence`, `text` (plus `usage` on the last event), and `sentence` only carries timing/word/text fields:

```json
{
  "sentence_id": 1, "begin_time": 200, "end_time": 6000,
  "text": "안녕하세요, 오늘 날씨가 참 좋네요. 함께 산책하러 갈까요. ",
  "channel_id": 0, "speaker_id": null, "sentence_end": true,
  "words": [{ "begin_time": 200, "end_time": 440, "text": "안", "punctuation": "", "fixed": true, "speaker_id": null }, ...],
  "stash": { "sentence_id": 2, "text": "", "begin_time": 6000, "current_time": 6000, "words": [] }
}
```

### Decision (per the issue's implementation order)

> If the server does not return detected-language metadata, record that result in this issue and do not add a separate language detector as part of this change.

→ **No separate language detector added; no `FinalLanguageRun` / `detected_language` wiring for Qwen Audio.** The translation layer keeps using the configured peer source language for Qwen Audio.

### Implementation status

The core wiring is implemented on branch `wire-qwen-audio-3.0-peer-language-auto-detection` (commit `ca3edf30`):

- `QwenAudioStreamingSTTBackend` now takes `language_hints: tuple[str, ...] = ()`; the `run-task` payload omits the `language_hints` key when empty, sends exactly one mapped hint for manual selection, and sends ordered multi-hint lists for constrained auto-detection. Repeated tasks reuse the same policy.
- Language Card `Auto Detect` is now offered for Qwen Audio; auto mode survives runtime normalization via a model-aware shared capability helper (`stt_supports_peer_auto_detection`), while ordinary `qwen-asr-flash-realtime` does not become auto-capable.
- `peer_expected_languages` maps to Qwen Audio codes preserving order, drops unsupported entries (no `en` coercion), dedupes aliases (`zh-CN`/`zh-TW` → `zh` keeps one slot), and is capped to the first four **only at the provider handoff** — the persisted list is never truncated (Soniox unaffected).

Full suite: 5285 passed / 33 skipped, ruff clean.


Closes #115