### PR TITLE
Apply staged STT provider changes to the live runtime

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -244,6 +244,8 @@ Examples:
 
 Runtime state belongs to its lifecycle owner and is not persisted settings.
 
+When a settings draft exits, the typed intent is persisted and then passed through the provider-apply boundary. For an active Self capture, provider application must converge both the Self capture owner and the Local ASR channel to the requested live runtime signature before the applied signature cache is updated. Idle or disabled Self capture does not force provider preparation. A smooth active handoff keeps the current provider until the owning translation channel completes the utterance at `SpeechEnd`; failed, cancelled, or non-converged application leaves the previous cache truth intact.
+
 ## Provider Boundaries
 
 ### STT

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -244,7 +244,7 @@ Examples:
 
 Runtime state belongs to its lifecycle owner and is not persisted settings.
 
-When a settings draft exits, the typed intent is persisted and then passed through the provider-apply boundary. For an active Self capture, provider application must converge both the Self capture owner and the Local ASR channel to the requested live runtime signature before the applied signature cache is updated. Idle or disabled Self capture does not force provider preparation. A smooth active handoff keeps the current provider until the owning translation channel completes the utterance at `SpeechEnd`; failed, cancelled, or non-converged application leaves the previous cache truth intact.
+When a settings draft exits, the typed intent is persisted and then passed through the provider-apply boundary. For an active Self capture, provider application must converge both the Self capture owner and the Local ASR channel to the requested live runtime signature before the applied signature cache is updated. Idle or disabled Self capture never forces preparation for an unrelated apply, but an explicit STT selection may still prepare the dormant provider without committing a live handoff. A smooth active handoff keeps the current provider until the owning translation channel completes the utterance at `SpeechEnd`; failed, cancelled, or non-converged application leaves the previous cache truth intact.
 
 ## Provider Boundaries
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -244,7 +244,7 @@ Examples:
 
 Runtime state belongs to its lifecycle owner and is not persisted settings.
 
-When a settings draft exits, the typed intent is persisted and then passed through the provider-apply boundary. For an active Self capture, provider application must converge both the Self capture owner and the Local ASR channel to the requested live runtime signature before the applied signature cache is updated. Active-only reconciliation never forces off-state preparation for an unrelated apply; an explicit STT provider selection may still prepare the selected dormant provider under the existing contract. A READY provider prepared while Self is disabled is not a live handoff commit. A smooth active handoff keeps the current provider until the owning translation channel completes the utterance at `SpeechEnd`; failed, cancelled, or non-converged application leaves the previous cache truth intact.
+When a settings draft exits, the typed intent is persisted and then passed through the provider-apply boundary. For an active Self capture, provider application must converge both the Self capture owner and the Local ASR channel to the requested live runtime signature before the applied signature cache is updated. Idle or disabled Self capture does not force provider preparation. A smooth active handoff keeps the current provider until the owning translation channel completes the utterance at `SpeechEnd`; failed, cancelled, or non-converged application leaves the previous cache truth intact.
 
 ## Provider Boundaries
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -244,7 +244,7 @@ Examples:
 
 Runtime state belongs to its lifecycle owner and is not persisted settings.
 
-When a settings draft exits, the typed intent is persisted and then passed through the provider-apply boundary. For an active Self capture, provider application must converge both the Self capture owner and the Local ASR channel to the requested live runtime signature before the applied signature cache is updated. Idle or disabled Self capture does not force provider preparation. A smooth active handoff keeps the current provider until the owning translation channel completes the utterance at `SpeechEnd`; failed, cancelled, or non-converged application leaves the previous cache truth intact.
+When a settings draft exits, the typed intent is persisted and then passed through the provider-apply boundary. For an active Self capture, provider application must converge both the Self capture owner and the Local ASR channel to the requested live runtime signature before the applied signature cache is updated. Active-only reconciliation never forces off-state preparation for an unrelated apply; an explicit STT provider selection may still prepare the selected dormant provider under the existing contract. A READY provider prepared while Self is disabled is not a live handoff commit. A smooth active handoff keeps the current provider until the owning translation channel completes the utterance at `SpeechEnd`; failed, cancelled, or non-converged application leaves the previous cache truth intact.
 
 ## Provider Boundaries
 

--- a/src/puripuly_heart/app/services/capture/self_capture_application.py
+++ b/src/puripuly_heart/app/services/capture/self_capture_application.py
@@ -120,6 +120,15 @@ class SelfCaptureApplicationOwner:
         settings = self.settings_provider()
         if settings is None or not self.runtime_available():
             return
+        requested_provider = settings.provider_id
+        current_provider = (
+            getattr(owner.snapshot, "provider_id", None) if owner is not None else None
+        )
+        self.log_detailed(
+            "[STT][Runtime] provider refresh requested: "
+            f"current={current_provider or 'none'} requested={requested_provider}",
+            logging.INFO,
+        )
         owner = self.capture_owner()
         config = settings.config
         if owner.snapshot.desired_active:
@@ -131,6 +140,22 @@ class SelfCaptureApplicationOwner:
             )
         else:
             snapshot = await owner.prepare_provider(config)
+        if (
+            snapshot.provider_status is SelfCaptureProviderStatus.READY
+            and snapshot.failure_reason is None
+            and snapshot.runtime_signature == config.runtime_signature
+        ):
+            self.log_detailed(
+                "[STT][Runtime] provider handoff committed: "
+                f"provider={getattr(snapshot, 'provider_id', config.provider_id)}",
+                logging.INFO,
+            )
+        elif snapshot.provider_status is SelfCaptureProviderStatus.PENDING:
+            self.log_detailed(
+                "[STT][Runtime] provider handoff pending: "
+                f"requested={config.provider_id} reason={snapshot.admission_reason or 'boundary'}",
+                logging.INFO,
+            )
         self.state_sink(snapshot)
         self.project_availability(snapshot)
         self.restart_requested = False

--- a/src/puripuly_heart/app/services/capture/self_capture_application.py
+++ b/src/puripuly_heart/app/services/capture/self_capture_application.py
@@ -145,11 +145,18 @@ class SelfCaptureApplicationOwner:
             and snapshot.failure_reason is None
             and snapshot.runtime_signature == config.runtime_signature
         ):
-            self.log_detailed(
-                "[STT][Runtime] provider handoff committed: "
-                f"provider={getattr(snapshot, 'provider_id', config.provider_id)}",
-                logging.INFO,
-            )
+            if snapshot.desired_active and snapshot.effective_active:
+                self.log_detailed(
+                    "[STT][Runtime] provider handoff committed: "
+                    f"provider={getattr(snapshot, 'provider_id', config.provider_id)}",
+                    logging.INFO,
+                )
+            else:
+                self.log_detailed(
+                    "[STT][Runtime] provider prepared: "
+                    f"provider={getattr(snapshot, 'provider_id', config.provider_id)}",
+                    logging.INFO,
+                )
         elif snapshot.provider_status is SelfCaptureProviderStatus.PENDING:
             self.log_detailed(
                 "[STT][Runtime] provider handoff pending: "

--- a/src/puripuly_heart/app/services/provider/provider_runtime_apply.py
+++ b/src/puripuly_heart/app/services/provider/provider_runtime_apply.py
@@ -60,11 +60,20 @@ ProviderRuntimeSignatureCacheProvider = Callable[
 ProviderRuntimeSignatureBuilder = Callable[[object], object]
 ProviderRuntimePeerSignatureBuilder = Callable[[object, object | None], object]
 ProviderRuntimeGpuRestartDecision = Callable[[object, object], bool]
+ProviderRuntimeSelfConvergenceProvider = Callable[[object], bool | None]
 LlmProviderReplace = Callable[[object | None], Awaitable[object | None]]
 LlmProviderFactory = Callable[[object], object | Awaitable[object | None] | None]
 LlmProviderRebuildContextProvider = Callable[[], "LlmProviderRebuildContext | None"]
 LlmProviderAvailabilitySink = Callable[[bool], None]
 LlmProviderMessageSink = Callable[[str], None]
+
+
+def _unknown_self_runtime_convergence(_settings: object) -> bool | None:
+    return None
+
+
+class ProviderRuntimeConvergenceError(RuntimeError):
+    code = "stt_runtime_apply_not_converged"
 
 
 @dataclass(frozen=True, slots=True)
@@ -121,6 +130,9 @@ class ProviderRuntimeOwner:
     peer_signature_builder: ProviderRuntimePeerSignatureBuilder
     llm_signature_builder: ProviderRuntimeSignatureBuilder
     gpu_restart_decision: ProviderRuntimeGpuRestartDecision
+    self_runtime_convergence: ProviderRuntimeSelfConvergenceProvider = (
+        _unknown_self_runtime_convergence
+    )
 
     def build_plan(
         self,
@@ -150,7 +162,9 @@ class ProviderRuntimeOwner:
             ),
             should_refresh_peer=(peer_signature is None or next_peer_signature != peer_signature),
             should_refresh_self_stt=(
-                self_signature is None or next_self_signature != self_signature
+                self_signature is None
+                or next_self_signature != self_signature
+                or self.self_runtime_convergence(next_settings) is False
             ),
             coordinated_gpu_restart=(
                 current_settings is not None
@@ -168,6 +182,7 @@ class ProviderRuntimeOwner:
             await self.rebuild_llm()
         if plan.coordinated_gpu_restart:
             await self.recover_gpu(settings, plan)
+            self._require_self_runtime_convergence(settings)
             self.signature_sink(settings)
             if plan.should_rebuild_llm and not self.state_provider(settings).llm_available:
                 self.llm_retry_sink()
@@ -176,9 +191,16 @@ class ProviderRuntimeOwner:
             await self.refresh_peer()
         if plan.should_refresh_self_stt:
             await self.refresh_self_stt()
+        self._require_self_runtime_convergence(settings)
         self.signature_sink(settings)
         if plan.should_rebuild_llm and not self.state_provider(settings).llm_available:
             self.llm_retry_sink()
+
+    def _require_self_runtime_convergence(self, settings: object) -> None:
+        if self.self_runtime_convergence(settings) is False:
+            raise ProviderRuntimeConvergenceError(
+                "Self STT runtime did not converge to requested settings",
+            )
 
     def unavailable_result(
         self,
@@ -431,7 +453,7 @@ class ProviderRuntimeApplyAdapter:
         _ = request
         try:
             await self.owner.apply(self.settings, self.plan)
-        except Exception:
+        except Exception as exc:
             return RuntimeApplyResult(
                 status=RUNTIME_APPLY_STATUS_FAILED,
                 message=UserMessageRef(
@@ -442,7 +464,11 @@ class ProviderRuntimeApplyAdapter:
                 diagnostics=_settings_mutation_diagnostics(
                     component="gui_controller",
                     operation=self.operation,
-                    code="provider_runtime_apply_exception",
+                    code=(
+                        getattr(exc, "code", None)
+                        if isinstance(getattr(exc, "code", None), str)
+                        else "provider_runtime_apply_exception"
+                    ),
                     category=DIAGNOSTIC_CATEGORY_LIFECYCLE,
                     surface=self.surface,
                 ),
@@ -574,7 +600,9 @@ __all__ = [
     "OverlayOscOutputRuntimeApplyAdapter",
     "ProviderRuntimeApplyAdapter",
     "ProviderRuntimeApplyPlan",
+    "ProviderRuntimeConvergenceError",
     "ProviderRuntimeOwner",
+    "ProviderRuntimeSelfConvergenceProvider",
     "ProviderRuntimeState",
     "SettingsRuntimeState",
     "SttLanguageAudioRuntimeApplyAdapter",

--- a/src/puripuly_heart/app/services/settings/settings_runtime_effects.py
+++ b/src/puripuly_heart/app/services/settings/settings_runtime_effects.py
@@ -39,6 +39,7 @@ from puripuly_heart.app.wiring_provider_runtime import (
 from puripuly_heart.app.wiring_runtime_pipeline import RuntimePipelineHandle
 from puripuly_heart.app.wiring_stt_factory import (
     build_peer_stt_runtime_signature_from_vnext,
+    build_self_capture_session_config_from_vnext,
     build_self_capture_vad_signature_from_vnext,
     build_self_stt_runtime_signature_from_vnext,
 )
@@ -409,6 +410,31 @@ class SettingsRuntimeEffectsAdapter:
     def sync_signatures(self, settings: AppSettingsVNext) -> None:
         self._sync_signatures(settings)
 
+    def _self_runtime_converged(self, settings: AppSettingsVNext) -> bool | None:
+        capture_provider = getattr(self, "_self_capture", None)
+        capture = capture_provider() if callable(capture_provider) else None
+        if capture is None or not capture.snapshot.desired_active:
+            return None
+        local_asr_runtime = getattr(self._pipeline, "local_asr_runtime", None)
+        if local_asr_runtime is None:
+            return False
+        expected = build_self_capture_session_config_from_vnext(self._canonical_settings(settings))
+        snapshot = capture.snapshot
+        channel = local_asr_runtime.snapshot.channel_for("self")
+        provider_status = getattr(snapshot.provider_status, "value", snapshot.provider_status)
+        return bool(
+            channel.provider_id == expected.provider_id
+            and channel.has_resources
+            and not channel.pending_handoff
+            and channel.phase in {"dormant", "ready", "running"}
+            and snapshot.provider_id == expected.provider_id
+            and snapshot.runtime_signature == expected.runtime_signature
+            and provider_status == "ready"
+            and snapshot.failure_reason is None
+            and snapshot.desired_active
+            == (snapshot.effective_active if snapshot.desired_active else False)
+        )
+
     def state(self, settings: AppSettingsVNext) -> SettingsRuntimeState:
         local_asr_runtime = self._pipeline.local_asr_runtime
         llm_runtime = self._pipeline.llm_runtime
@@ -515,6 +541,7 @@ class SettingsRuntimeEffectsAdapter:
 
         canonical = self._canonical_settings(settings)
         current_self_signature = build_self_stt_runtime_signature_from_vnext(canonical)
+        self_runtime_converged = self._self_runtime_converged(canonical)
         current_peer_signature = build_peer_stt_runtime_signature_from_vnext(canonical)
         next_peer_activation_requested = self._peer.owner.activation_requested(
             intent_enabled=self._settings.peer_translation_enabled(),
@@ -523,7 +550,7 @@ class SettingsRuntimeEffectsAdapter:
         should_restart_stt = (
             transition.previous_self_signature is not None
             and current_self_signature != transition.previous_self_signature
-        )
+        ) or self_runtime_converged is False
         should_refresh_peer = (
             transition.previous_peer_signature is None
             or current_peer_signature != transition.previous_peer_signature
@@ -531,8 +558,6 @@ class SettingsRuntimeEffectsAdapter:
             != self._settings.peer_translation_enabled()
             or transition.previous_peer_activation_requested != next_peer_activation_requested
         )
-
-        self._sync_signatures(settings)
 
         if transition.source_language_changed or transition.target_language_changed:
             self._runtime_logging.emit_detailed(
@@ -556,6 +581,8 @@ class SettingsRuntimeEffectsAdapter:
                 == build_self_capture_vad_signature_from_vnext(canonical)
             )
             await self._replace_self_stt(smooth_local)
+
+        self._sync_signatures(settings)
 
         if reload_settings_view and (
             transition.source_language_changed

--- a/src/puripuly_heart/app/wiring/wiring_provider_runtime.py
+++ b/src/puripuly_heart/app/wiring/wiring_provider_runtime.py
@@ -221,6 +221,32 @@ class ProviderRuntimeEffects:
             peer_stt_desired=self.peer_desired(settings),
         )
 
+    def self_runtime_convergence(self, settings: object) -> bool | None:
+        runtime = self.local_asr_runtime_provider()
+        owner = self.self_capture_provider()
+        if owner is None:
+            return None
+        if runtime is None:
+            return False if owner.snapshot.desired_active else None
+        expected = build_self_capture_session_config_from_vnext(
+            self.canonical_settings(settings),
+        )
+        capture = owner.snapshot
+        channel = runtime.snapshot.channel_for("self")
+        provider_status = getattr(capture.provider_status, "value", capture.provider_status)
+        return bool(
+            channel.provider_id == expected.provider_id
+            and channel.has_resources
+            and not channel.pending_handoff
+            and channel.phase in {"dormant", "ready", "running"}
+            and capture.provider_id == expected.provider_id
+            and capture.runtime_signature == expected.runtime_signature
+            and provider_status == "ready"
+            and capture.failure_reason is None
+            and capture.desired_active
+            == (capture.effective_active if capture.desired_active else False)
+        )
+
     def apply_common(self, settings: AppSettingsVNext) -> None:
         canonical = self.canonical_settings(settings)
         translation = canonical.intent.translation
@@ -519,6 +545,7 @@ def compose_provider_runtime(
             canonical_settings(current),
             canonical_settings(next_value),
         ),
+        self_runtime_convergence=effects.self_runtime_convergence,
     )
     return ProviderRuntimeComponents(
         runtime=runtime,

--- a/src/puripuly_heart/app/wiring/wiring_provider_runtime.py
+++ b/src/puripuly_heart/app/wiring/wiring_provider_runtime.py
@@ -224,10 +224,10 @@ class ProviderRuntimeEffects:
     def self_runtime_convergence(self, settings: object) -> bool | None:
         runtime = self.local_asr_runtime_provider()
         owner = self.self_capture_provider()
-        if owner is None:
+        if owner is None or not owner.snapshot.desired_active:
             return None
         if runtime is None:
-            return False if owner.snapshot.desired_active else None
+            return False
         expected = build_self_capture_session_config_from_vnext(
             self.canonical_settings(settings),
         )

--- a/src/puripuly_heart/composition/application_runtime.py
+++ b/src/puripuly_heart/composition/application_runtime.py
@@ -419,6 +419,7 @@ def compose_application_runtime(
     audio_diagnostics: AudioDiagnosticsApplicationOwner | None = None
     self_application: SelfCaptureApplicationOwner | None = None
     microphone: MicrophoneTestRuntime | None = None
+    last_self_capture_lifecycle: str | None = None
     vrc_mic_sync: OscControlIntegrationOwner | None = None
     manual_typing: ManualTypingOwner | None = None
     clipboard: ClipboardAutoTranslationOwner | None = None
@@ -976,7 +977,32 @@ def compose_application_runtime(
         if vrc_mic_sync is not None:
             vrc_mic_sync.publish_delta()
 
-    def on_self_capture_state(_snapshot: SelfCaptureSessionSnapshot) -> None:
+    def on_self_capture_state(snapshot: SelfCaptureSessionSnapshot) -> None:
+        nonlocal last_self_capture_lifecycle
+        provider_status = getattr(snapshot.provider_status, "value", snapshot.provider_status)
+        capture_state = getattr(snapshot.state, "value", snapshot.state)
+        if (
+            snapshot.failure_reason is not None
+            or provider_status == "failed"
+            or capture_state == "faulted"
+        ):
+            lifecycle = "failed"
+        elif provider_status == "pending":
+            lifecycle = "pending"
+        elif capture_state in {"admission_pending", "starting"}:
+            lifecycle = "preparing"
+        elif provider_status == "ready" and snapshot.desired_active and snapshot.effective_active:
+            lifecycle = "committed"
+        elif provider_status == "releasing" or capture_state == "stopping":
+            lifecycle = "stopping"
+        else:
+            lifecycle = "idle"
+        if lifecycle != last_self_capture_lifecycle:
+            log_basic(
+                "[STT][Runtime] self capture "
+                f"{lifecycle}: provider={snapshot.provider_id or 'none'}"
+            )
+            last_self_capture_lifecycle = lifecycle
         require_local_asr().adapters.notice.sync()
         publish_osc_state_from_runtime()
 

--- a/src/puripuly_heart/ui/app.py
+++ b/src/puripuly_heart/ui/app.py
@@ -1069,6 +1069,8 @@ class TranslatorApp:
                 if pending_settings is not None:
                     self.view_settings.has_provider_changes = False
 
+                    self._log_basic("[Settings] Applying staged provider intent")
+
                     async def _task():
                         await self.application.apply_provider_intent(pending_settings)
 
@@ -1554,6 +1556,8 @@ class TranslatorApp:
         ):
             pending_intent = consume_provider_apply_settings()
             view_settings.has_provider_changes = False
+        if pending_intent is not None:
+            self._log_basic("[Settings] Applying staged provider intent")
 
         async def _task():
             if pending_intent is None:

--- a/src/puripuly_heart/ui/views/settings.py
+++ b/src/puripuly_heart/ui/views/settings.py
@@ -4609,7 +4609,7 @@ class SettingsView(ft.Column):
             return
         old_provider = current_settings.stt_provider.value
         self._emit_runtime_basic(
-            f"[Settings] STT provider changed: {old_provider} -> {selected.value}"
+            f"[Settings] STT provider draft changed: {old_provider} -> {selected.value}"
         )
         draft = self._ensure_provider_settings_draft()
         self._provider_draft = replace(

--- a/tests/app/test_provider_runtime_owner.py
+++ b/tests/app/test_provider_runtime_owner.py
@@ -26,6 +26,7 @@ def _runtime_owner(
     state: ProviderRuntimeState,
     current: object | None = None,
     cache: tuple[object | None, object | None, object | None] = (None, None, None),
+    convergence=None,
 ) -> ProviderRuntimeOwner:
     async def record(name: str) -> None:
         events.append(name)
@@ -52,6 +53,7 @@ def _runtime_owner(
         ),
         llm_signature_builder=lambda settings: ("llm", settings),
         gpu_restart_decision=lambda _current, _next: True,
+        self_runtime_convergence=convergence or (lambda _settings: None),
     )
 
 
@@ -74,6 +76,49 @@ def test_provider_runtime_owner_builds_plan_from_owned_signature_state() -> None
         should_refresh_self_stt=True,
         coordinated_gpu_restart=True,
     )
+
+
+def test_provider_runtime_owner_forces_self_refresh_when_live_runtime_is_stale() -> None:
+    owner = _runtime_owner(
+        events=[],
+        state=ProviderRuntimeState(True, True, True, True, True, False),
+        current="next",
+        cache=(("self", "next"), ("peer",), ("llm", "next")),
+        convergence=lambda _settings: False,
+    )
+
+    plan = owner.build_plan("next", force_rebuild_llm=False)
+
+    assert plan.should_refresh_self_stt is True
+
+
+@pytest.mark.asyncio
+async def test_provider_runtime_owner_rejects_stale_self_runtime_before_caching_success() -> None:
+    events: list[str] = []
+    owner = _runtime_owner(
+        events=events,
+        state=ProviderRuntimeState(True, True, True, True, True, False),
+        convergence=lambda _settings: False,
+    )
+
+    with pytest.raises(RuntimeError, match="did not converge"):
+        await owner.apply("settings", ProviderRuntimeApplyPlan(False, False, False))
+
+    assert events == ["common"]
+
+
+@pytest.mark.asyncio
+async def test_provider_runtime_owner_caches_only_after_self_runtime_converges() -> None:
+    events: list[str] = []
+    owner = _runtime_owner(
+        events=events,
+        state=ProviderRuntimeState(True, True, True, True, True, False),
+        convergence=lambda _settings: True,
+    )
+
+    await owner.apply("settings", ProviderRuntimeApplyPlan(False, False, False))
+
+    assert events == ["common", "signatures"]
 
 
 @pytest.mark.asyncio

--- a/tests/app/test_self_capture_application_owner.py
+++ b/tests/app/test_self_capture_application_owner.py
@@ -53,6 +53,8 @@ async def test_replace_provider_propagates_updated_config_by_capture_activity(
                 provider_status=SelfCaptureProviderStatus.READY,
                 failure_reason=None,
                 runtime_signature=capture_config.runtime_signature,
+                desired_active=desired_active,
+                effective_active=desired_active,
             )
 
         async def apply_intent(self, config: object, **kwargs: object) -> object:
@@ -61,6 +63,8 @@ async def test_replace_provider_propagates_updated_config_by_capture_activity(
                 provider_status=SelfCaptureProviderStatus.READY,
                 failure_reason=None,
                 runtime_signature=capture_config.runtime_signature,
+                desired_active=desired_active,
+                effective_active=desired_active,
             )
 
     capture_owner = CaptureOwner()

--- a/tests/app/test_settings_runtime_effects.py
+++ b/tests/app/test_settings_runtime_effects.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+
+from puripuly_heart.app.ports.settings_runtime_effects import SettingsRuntimeTransition
+from puripuly_heart.app.services.settings.settings_runtime_effects import (
+    SettingsRuntimeEffectsAdapter,
+)
+from puripuly_heart.app.wiring.wiring_stt_factory import (
+    build_peer_stt_runtime_signature_from_vnext,
+)
+from puripuly_heart.config.settings_vnext.schema import AppSettingsVNext
+
+
+class _AsyncNoop:
+    async def apply_controls(self, _controls) -> None:
+        return None
+
+    async def sync(self, **_kwargs) -> None:
+        return None
+
+    async def inspect_cpu(self) -> None:
+        return None
+
+    async def inspect_gpu(self, **_kwargs) -> None:
+        return None
+
+
+class _Overlay:
+    snapshot = SimpleNamespace(fallback_active=False)
+
+    def current_presenter(self):
+        return None
+
+    def runtime_is_active(self) -> bool:
+        return False
+
+    def set_enabled(self, _enabled):
+        return None
+
+    def publish_presentation(self) -> None:
+        return None
+
+
+class _VrcMic:
+    last_enabled = False
+
+    async def configure(self, **_kwargs) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_failed_self_runtime_apply_does_not_write_target_signature_cache_first() -> None:
+    previous = AppSettingsVNext()
+    target = replace(
+        previous,
+        intent=replace(
+            previous.intent,
+            stt=replace(previous.intent.stt, provider="soniox"),
+        ),
+    )
+    events: list[str] = []
+    adapter = object.__new__(SettingsRuntimeEffectsAdapter)
+    adapter._desktop_overlay = _AsyncNoop()
+    adapter._clipboard = SimpleNamespace(strict_runtime_errors=False, sync=_AsyncNoop().sync)
+    adapter._provisioning = _AsyncNoop()
+    adapter._clear_local_pending = lambda: None
+    adapter._pipeline = SimpleNamespace(
+        translation_runtime_configuration=None,
+        peer_translation_channel=None,
+    )
+    adapter._peer = SimpleNamespace(
+        owner=SimpleNamespace(
+            effective_enabled=lambda: False,
+            activation_requested=lambda **_kwargs: False,
+        )
+    )
+    adapter._settings = SimpleNamespace(
+        overlay_enabled=lambda: False,
+        peer_translation_enabled=lambda: False,
+    )
+    adapter._gpu = SimpleNamespace(
+        state_provider=lambda: SimpleNamespace(selected_provider_requires_model=False)
+    )
+    adapter._overlay = _Overlay()
+    adapter._vrc_mic_sync = _VrcMic()
+    adapter._runtime_logging = SimpleNamespace(emit_detailed=lambda *_args, **_kwargs: None)
+    adapter._presentation = SimpleNamespace(current_locale=lambda: "en")
+    adapter._projection = SimpleNamespace()
+    adapter._rebuild_managed_gemma = lambda: None
+    adapter._canonical_settings = lambda value: value
+    adapter._sync_effective_translation_flags = lambda _settings: None
+    adapter._sync_signatures = lambda _settings: events.append("signature_cache_write")
+
+    async def fail_self_replace(_smooth: bool) -> None:
+        events.append("self_replace")
+        raise RuntimeError("boundary handoff failed")
+
+    adapter._replace_self_stt = fail_self_replace
+    transition = SettingsRuntimeTransition(
+        settings=target,
+        previous_settings=previous,
+        previous_locale="en",
+        previous_overlay_enabled=False,
+        previous_self_signature=("previous",),
+        previous_peer_signature=None,
+        previous_peer_translation_enabled=False,
+        previous_peer_activation_requested=False,
+        source_language_changed=False,
+        target_language_changed=False,
+        effective_peer_source_changed=False,
+        effective_peer_target_changed=False,
+        peer_source_language_changed=False,
+        peer_target_language_changed=False,
+        peer_source_mode_changed=False,
+        desktop_runtime_controls=(),
+    )
+
+    with pytest.raises(RuntimeError, match="boundary handoff failed"):
+        await adapter.apply_after_persist(
+            transition,
+            strict_runtime_errors=False,
+            reload_settings_view=False,
+        )
+
+    assert events == ["self_replace"]
+
+
+@pytest.mark.asyncio
+async def test_peer_refresh_recomputes_activation_after_eula_transition() -> None:
+    previous = AppSettingsVNext()
+    target = replace(
+        previous,
+        state=replace(
+            previous.state,
+            peer_translation=replace(
+                previous.state.peer_translation,
+                eula_accepted=True,
+            ),
+        ),
+    )
+    events: list[str] = []
+    activation_calls: list[tuple[bool, bool]] = []
+    adapter = object.__new__(SettingsRuntimeEffectsAdapter)
+    adapter._desktop_overlay = _AsyncNoop()
+    adapter._clipboard = SimpleNamespace(strict_runtime_errors=False, sync=_AsyncNoop().sync)
+    adapter._provisioning = _AsyncNoop()
+    adapter._clear_local_pending = lambda: None
+    adapter._pipeline = SimpleNamespace(
+        translation_runtime_configuration=None,
+        peer_translation_channel=object(),
+    )
+
+    def activation_requested(*, intent_enabled: bool, eula_accepted: bool) -> bool:
+        activation_calls.append((intent_enabled, eula_accepted))
+        return intent_enabled and eula_accepted
+
+    async def refresh_peer() -> None:
+        events.append("peer_refresh")
+
+    adapter._peer = SimpleNamespace(
+        owner=SimpleNamespace(
+            effective_enabled=lambda _state=None: True,
+            activation_requested=activation_requested,
+            refresh_runtime=refresh_peer,
+        ),
+        state_for=lambda _channel: object(),
+    )
+    adapter._settings = SimpleNamespace(
+        authoritative=False,
+        overlay_enabled=lambda: False,
+        peer_translation_enabled=lambda: True,
+    )
+    adapter._gpu = SimpleNamespace(
+        state_provider=lambda: SimpleNamespace(selected_provider_requires_model=False)
+    )
+    adapter._overlay = _Overlay()
+    adapter._vrc_mic_sync = _VrcMic()
+    adapter._runtime_logging = SimpleNamespace(
+        emit_detailed=lambda *_args, **_kwargs: None,
+        emit_basic=lambda *_args, **_kwargs: None,
+    )
+    adapter._presentation = SimpleNamespace(current_locale=lambda: "en")
+    adapter._projection = SimpleNamespace()
+    adapter._rebuild_managed_gemma = lambda: None
+    adapter._canonical_settings = lambda value: value
+    adapter._sync_effective_translation_flags = lambda _settings: events.append("peer_flags")
+    adapter._sync_signatures = lambda _settings: events.append("signature_cache_write")
+
+    async def no_self_replace(_smooth: bool) -> None:
+        events.append("self_replace")
+
+    adapter._replace_self_stt = no_self_replace
+    transition = SettingsRuntimeTransition(
+        settings=target,
+        previous_settings=previous,
+        previous_locale="en",
+        previous_overlay_enabled=False,
+        previous_self_signature=None,
+        previous_peer_signature=build_peer_stt_runtime_signature_from_vnext(target),
+        previous_peer_translation_enabled=True,
+        previous_peer_activation_requested=False,
+        source_language_changed=False,
+        target_language_changed=False,
+        effective_peer_source_changed=False,
+        effective_peer_target_changed=False,
+        peer_source_language_changed=False,
+        peer_target_language_changed=False,
+        peer_source_mode_changed=False,
+        desktop_runtime_controls=(),
+    )
+
+    await adapter.apply_after_persist(
+        transition,
+        strict_runtime_errors=False,
+        reload_settings_view=False,
+    )
+
+    assert activation_calls == [(True, True)]
+    assert events == ["peer_refresh", "peer_flags", "signature_cache_write"]

--- a/tests/app/test_stt_provider_apply_vertical.py
+++ b/tests/app/test_stt_provider_apply_vertical.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from uuid import uuid4
 
+import numpy as np
 import pytest
 from puripuly_heart.app.services.settings_transaction_result import SettingsTransactionResultOwner
 from puripuly_heart.core.local_asr_provider_runtime import (
@@ -20,13 +21,16 @@ from puripuly_heart.app.adapters.ui_runtime import (
     UiProviderRuntimeAdapter,
     UiSettingsRuntimeAdapter,
 )
-from puripuly_heart.app.ports.settings_view import ProviderApplyIntent, SelfSttProviderEdit
+from puripuly_heart.app.ports.settings_view import ProviderApplyIntent
 from puripuly_heart.app.services.canonical_settings_persistence import compose_settings_owner
 from puripuly_heart.app.services.capture.self_capture_application import (
     SelfCaptureApplicationOwner,
     SelfCaptureApplicationSettings,
 )
 from puripuly_heart.app.services.provider.provider_settings import ProviderApplicationOwner
+from puripuly_heart.app.services.settings.settings_application import (
+    settings_view_surface_snapshots,
+)
 from puripuly_heart.app.services.ui_application import UiApplicationBoundary
 from puripuly_heart.app.wiring.wiring_provider_runtime import compose_provider_runtime
 from puripuly_heart.app.wiring.wiring_stt_factory import (
@@ -36,6 +40,9 @@ from puripuly_heart.app.wiring.wiring_stt_factory import (
 from puripuly_heart.config.provider_values import STTProviderName
 from puripuly_heart.config.settings_vnext.schema import AppSettingsVNext
 from puripuly_heart.core.clock import SystemClock
+from puripuly_heart.core.messages import (
+    TRANSACTION_STATUS_SETTINGS_COMMIT_SUCCESS_RUNTIME_DEGRADED,
+)
 from puripuly_heart.core.runtime.local_asr_provider_runtime import (
     LocalASRProviderRuntimeOwner,
 )
@@ -48,7 +55,8 @@ from puripuly_heart.core.self_capture import (
 from puripuly_heart.core.stt.backend import STTBackendTranscriptEvent
 from puripuly_heart.core.stt.controller import ManagedSTTProvider
 from puripuly_heart.core.stt.rolling import RollingProviderDefinition, RollingSTTBackend
-from puripuly_heart.core.vad.gating import SpeechEnd
+from puripuly_heart.core.vad.gating import SpeechChunk, SpeechEnd, SpeechStart
+from puripuly_heart.ui.views.settings import SettingsView
 from tests.core.runtime.test_local_asr_provider_runtime import (
     FakeGpuRuntimeFactory,
     FakeProvisioningPort,
@@ -207,6 +215,7 @@ def _settings(provider: str) -> AppSettingsVNext:
 @pytest.mark.asyncio
 async def test_provider_apply_intent_full_vertical_rolling_gemini_soniox_reverse_and_speech_end(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     settings_owner = compose_settings_owner(tmp_path / "settings.json")
     settings_owner.start()
@@ -374,9 +383,53 @@ async def test_provider_apply_intent_full_vertical_rolling_gemini_soniox_reverse
         osc_state_publisher=lambda: None,
     )
 
-    soniox_intent = ProviderApplyIntent((SelfSttProviderEdit(STTProviderName.SONIOX),))
+    monkeypatch.setattr(SettingsView, "_populate_host_apis", lambda self: None)
+    monkeypatch.setattr(SettingsView, "_refresh_microphones", lambda self: None)
+    monkeypatch.setattr(SettingsView, "update", lambda self: None)
+    monkeypatch.setattr(SettingsView, "_load_secrets", lambda self, *_args: None)
+    settings_view = SettingsView()
+    baseline_settings = settings_owner.canonical
+    assert baseline_settings is not None
+    (
+        provider_snapshot,
+        general_snapshot,
+        prompt_snapshot,
+        overlay_snapshot,
+    ) = settings_view_surface_snapshots(baseline_settings)
+    settings_view.load_from_settings(
+        provider=provider_snapshot,
+        general=general_snapshot,
+        prompt=prompt_snapshot,
+        overlay=overlay_snapshot,
+        config_path=tmp_path / "settings.json",
+    )
+    settings_view._on_stt_selected(STTProviderName.SONIOX.value)
+    assert settings_view._provider_draft is not None
+    assert settings_view._provider_draft.stt_provider is STTProviderName.SONIOX
+    assert settings_owner.canonical.intent.stt.provider == STTProviderName.ROLLING_FREE.value
+    assert runtime.current_provider("self") is initial_provider
+    assert runtime.snapshot.channel_for("self").provider_id == STTProviderName.ROLLING_FREE.value
+    assert capture_owner.snapshot.provider_id == STTProviderName.ROLLING_FREE.value
+    soniox_intent = settings_view.build_provider_apply_settings()
+    assert isinstance(soniox_intent, ProviderApplyIntent)
+
+    original_refresh_self_stt = components.runtime.refresh_self_stt
+    original_self_runtime_convergence = components.runtime.self_runtime_convergence
+    components.runtime.refresh_self_stt = _noop
+    components.runtime.self_runtime_convergence = lambda _settings: False
     await boundary.apply_provider_intent(soniox_intent)
-    assert settings_owner.canonical is not None
+    stale_result = results.current
+    assert stale_result is not None
+    assert stale_result.status == TRANSACTION_STATUS_SETTINGS_COMMIT_SUCCESS_RUNTIME_DEGRADED
+    assert stale_result.diagnostics is not None
+    assert stale_result.diagnostics.code == "stt_runtime_apply_not_converged"
+    assert settings_owner.canonical.intent.stt.provider == STTProviderName.SONIOX.value
+    assert runtime.current_provider("self") is initial_provider
+    assert capture_owner.snapshot.provider_id == STTProviderName.ROLLING_FREE.value
+    assert runtime.snapshot.channel_for("self").provider_id == STTProviderName.ROLLING_FREE.value
+    components.runtime.refresh_self_stt = original_refresh_self_stt
+    components.runtime.self_runtime_convergence = original_self_runtime_convergence
+    await boundary.apply_provider_intent(soniox_intent)
     assert settings_owner.canonical.intent.stt.provider == STTProviderName.SONIOX.value
     soniox_provider = runtime.current_provider("self")
     assert soniox_provider is not None
@@ -389,8 +442,15 @@ async def test_provider_apply_intent_full_vertical_rolling_gemini_soniox_reverse
     assert capture_owner.source is source
     assert capture_owner.loop_task is loop_task
 
-    rolling_intent = ProviderApplyIntent((SelfSttProviderEdit(STTProviderName.ROLLING_FREE),))
-    soniox_provider._active_utterance_id = uuid4()
+    settings_view._on_stt_selected(STTProviderName.ROLLING_FREE.value)
+    rolling_intent = settings_view.build_provider_apply_settings()
+    assert isinstance(rolling_intent, ProviderApplyIntent)
+    utterance_id = uuid4()
+    frame = np.zeros(512, dtype=np.float32)
+    await harness.self_owner.handle_vad_event(SpeechStart(utterance_id, frame, frame))
+    await harness.self_owner.handle_vad_event(SpeechChunk(utterance_id, frame))
+    old_transport = harness_factory.provider_factory.backends[-1]
+    assert isinstance(old_transport, _TransportBackend)
     apply_rolling = asyncio.create_task(boundary.apply_provider_intent(rolling_intent))
     for _ in range(1000):
         await asyncio.sleep(0.001)
@@ -400,8 +460,10 @@ async def test_provider_apply_intent_full_vertical_rolling_gemini_soniox_reverse
     assert runtime.snapshot.channel_for("self").pending_handoff is True
     assert runtime.snapshot.channel_for("self").provider_id == STTProviderName.SONIOX.value
     assert capture_owner.snapshot.provider_id == STTProviderName.SONIOX.value
-    await harness.self_owner.handle_vad_event(SpeechEnd(uuid4()))
+    await harness.self_owner.handle_vad_event(SpeechEnd(utterance_id))
     await apply_rolling
+    assert old_transport.sessions
+    assert old_transport.sessions[-1].speech_ends
 
     restored = runtime.current_provider("self")
     assert restored is not None
@@ -417,8 +479,38 @@ async def test_provider_apply_intent_full_vertical_rolling_gemini_soniox_reverse
     assert capture_owner.snapshot.effective_active is True
     assert capture_owner.source is source
     assert capture_owner.loop_task is loop_task
+    provider_count_before_disable = len(harness_factory.provider_factory.providers)
+    await capture_owner.apply_intent(
+        expected,
+        enabled=False,
+        explicit_toggle_off=True,
+    )
+    assert capture_owner.snapshot.desired_active is False
+    detached_channel = runtime.snapshot.channel_for("self")
+    unrelated_settings = replace(
+        settings_owner.canonical,
+        intent=replace(
+            settings_owner.canonical.intent,
+            translation=replace(
+                settings_owner.canonical.intent.translation,
+                concurrency_limit=(
+                    settings_owner.canonical.intent.translation.concurrency_limit + 1
+                ),
+            ),
+        ),
+    )
+    unrelated_plan = components.runtime.build_plan(
+        unrelated_settings,
+        force_rebuild_llm=False,
+    )
+    assert unrelated_plan.should_refresh_self_stt is False
+    await components.runtime.apply(unrelated_settings, unrelated_plan)
+    assert len(harness_factory.provider_factory.providers) == provider_count_before_disable
+    assert runtime.snapshot.channel_for("self").provider_id == detached_channel.provider_id
+    assert capture_owner.snapshot.desired_active is False
 
     await capture_owner.close()
+
     await runtime.close()
 
 

--- a/tests/app/test_stt_provider_apply_vertical.py
+++ b/tests/app/test_stt_provider_apply_vertical.py
@@ -1,0 +1,430 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from puripuly_heart.app.services.settings_transaction_result import SettingsTransactionResultOwner
+from puripuly_heart.core.local_asr_provider_runtime import (
+    LocalASRProviderRuntimeCallbacks,
+)
+
+from puripuly_heart.app.adapters.self_capture.self_capture_provider import (
+    SelfCaptureProviderAdapter,
+)
+from puripuly_heart.app.adapters.ui_runtime import (
+    UiProviderRuntimeAdapter,
+    UiSettingsRuntimeAdapter,
+)
+from puripuly_heart.app.ports.settings_view import ProviderApplyIntent, SelfSttProviderEdit
+from puripuly_heart.app.services.canonical_settings_persistence import compose_settings_owner
+from puripuly_heart.app.services.capture.self_capture_application import (
+    SelfCaptureApplicationOwner,
+    SelfCaptureApplicationSettings,
+)
+from puripuly_heart.app.services.provider.provider_settings import ProviderApplicationOwner
+from puripuly_heart.app.services.ui_application import UiApplicationBoundary
+from puripuly_heart.app.wiring.wiring_provider_runtime import compose_provider_runtime
+from puripuly_heart.app.wiring.wiring_stt_factory import (
+    build_self_capture_session_config_from_vnext,
+    build_self_stt_provider_request_from_vnext,
+)
+from puripuly_heart.config.provider_values import STTProviderName
+from puripuly_heart.config.settings_vnext.schema import AppSettingsVNext
+from puripuly_heart.core.clock import SystemClock
+from puripuly_heart.core.runtime.local_asr_provider_runtime import (
+    LocalASRProviderRuntimeOwner,
+)
+from puripuly_heart.core.runtime.provider_handle import ProviderRuntimeHandle
+from puripuly_heart.core.runtime.self_capture import SelfCaptureSessionOwner
+from puripuly_heart.core.self_capture import (
+    SelfCaptureAdmission,
+    SelfCaptureAdmissionStatus,
+)
+from puripuly_heart.core.stt.backend import STTBackendTranscriptEvent
+from puripuly_heart.core.stt.controller import ManagedSTTProvider
+from puripuly_heart.core.stt.rolling import RollingProviderDefinition, RollingSTTBackend
+from puripuly_heart.core.vad.gating import SpeechEnd
+from tests.core.runtime.test_local_asr_provider_runtime import (
+    FakeGpuRuntimeFactory,
+    FakeProvisioningPort,
+)
+from tests.helpers.fakes import RecordingOscQueue
+from tests.helpers.translation_owners import compose_translation_test_harness
+
+
+class _TransportSession:
+    def __init__(self) -> None:
+        self.closed = asyncio.Event()
+        self.speech_ends: list[object] = []
+
+    async def send_audio(self, _pcm16le: bytes) -> None:
+        return None
+
+    async def on_speech_end(self, *, trailing_silence_ms=None, reason=None) -> None:
+        self.speech_ends.append((trailing_silence_ms, reason))
+
+    async def stop(self) -> None:
+        self.closed.set()
+
+    async def close(self) -> None:
+        self.closed.set()
+
+    async def events(self):
+        await self.closed.wait()
+        if False:
+            yield STTBackendTranscriptEvent(text="", is_final=True)
+
+
+class _TransportBackend:
+    def __init__(self) -> None:
+        self.sessions: list[_TransportSession] = []
+
+    async def open_session(self) -> _TransportSession:
+        session = _TransportSession()
+        self.sessions.append(session)
+        return session
+
+
+class _ManagedProviderFactory:
+
+    def __init__(self) -> None:
+        self.providers: list[ManagedSTTProvider] = []
+        self.backends: list[object] = []
+
+    async def create(self, request, *, gpu_runtime, on_terminal_failure=None):
+        _ = gpu_runtime
+        transport = _TransportBackend()
+        self.backends.append(transport)
+        if request.provider_id == STTProviderName.ROLLING_FREE.value:
+            backend = RollingSTTBackend(
+                providers=(
+                    RollingProviderDefinition(
+                        name=STTProviderName.GEMINI_TRANSCRIBE,
+                        build_backend=lambda transport=transport: transport,
+                        is_configured=lambda: True,
+                    ),
+                )
+            )
+        else:
+            backend = transport
+        provider = ManagedSTTProvider(
+            backend=backend,
+            sample_rate_hz=request.config.sample_rate_hz,
+            stt_provider_name=STTProviderName(request.provider_id),
+            channel=request.channel,
+            clock=SystemClock(),
+            reset_deadline_s=2.0,
+            drain_timeout_s=0.2,
+            bridging_ms=200,
+            connect_attempts=1,
+        )
+        self.providers.append(provider)
+        if request.session_options is not None:
+            await provider.reconfigure_session_options(request.session_options)
+        return provider
+
+
+class _RuntimeFactory:
+    def __init__(self) -> None:
+        self.provider_factory = _ManagedProviderFactory()
+        self.runtime: LocalASRProviderRuntimeOwner | None = None
+
+    def create(self, callbacks: LocalASRProviderRuntimeCallbacks):
+        self.runtime = LocalASRProviderRuntimeOwner(
+            provider_factory=self.provider_factory,
+            gpu_runtime_factory=FakeGpuRuntimeFactory(),
+            provisioning=FakeProvisioningPort(),
+            self_event_handler=callbacks.self_event_handler,
+            peer_event_handler=callbacks.peer_event_handler,
+            retired_event_handler=callbacks.retired_event_handler,
+            self_exception_handler=callbacks.self_exception_handler,
+            peer_exception_handler=callbacks.peer_exception_handler,
+        )
+        return self.runtime
+
+
+class _Admission:
+    async def admit(self, _config):
+        return SelfCaptureAdmission(SelfCaptureAdmissionStatus.ADMITTED)
+
+
+class _Source:
+    async def close(self) -> None:
+        return None
+
+
+class _ChannelReset:
+    async def reset_provider_channel(self, _channel: str) -> None:
+        return None
+
+
+class _Peer:
+    last_provider_signature = None
+    last_runtime_signature = None
+    last_intent_enabled = False
+    last_activation_requested = False
+
+    def effective_enabled(self) -> bool:
+        return False
+
+    def activation_requested(self, *, intent_enabled: bool, eula_accepted: bool) -> bool:
+        return bool(intent_enabled and eula_accepted)
+
+
+class _ManagedRelease:
+    service = None
+
+    async def rebuild(self, **_kwargs) -> None:
+        return None
+
+
+class _NoopPort:
+    def __getattr__(self, _name):
+        return _noop
+
+
+async def _noop() -> None:
+    return None
+
+
+def _settings(provider: str) -> AppSettingsVNext:
+    base = AppSettingsVNext()
+    return replace(
+        base,
+        intent=replace(
+            base.intent,
+            stt=replace(base.intent.stt, provider=provider),
+            languages=replace(base.intent.languages, source_language="ko"),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_provider_apply_intent_full_vertical_rolling_gemini_soniox_reverse_and_speech_end(
+    tmp_path: Path,
+) -> None:
+    settings_owner = compose_settings_owner(tmp_path / "settings.json")
+    settings_owner.start()
+    settings_owner.canonical = _settings(STTProviderName.ROLLING_FREE.value)
+    harness_factory = _RuntimeFactory()
+    harness = compose_translation_test_harness(
+        stt=None,
+        llm=None,
+        osc=RecordingOscQueue(),
+        local_asr_provider_runtime_factory=harness_factory,
+    )
+    runtime = harness_factory.runtime
+    assert runtime is not None
+    peer = _Peer()
+    llm_runtime = ProviderRuntimeHandle(name="llm", provider=object())
+    sources: list[_Source] = []
+
+    async def source_factory(_config):
+        source = _Source()
+        sources.append(source)
+        return source
+
+    async def run_audio_loop(**_kwargs):
+        await asyncio.Event().wait()
+
+    def request_factory(config, _warmup):
+        current = settings_owner.canonical
+        assert current is not None
+        return build_self_stt_provider_request_from_vnext(current)
+
+    config_a = build_self_capture_session_config_from_vnext(settings_owner.canonical)
+    capture_owner = SelfCaptureSessionOwner(
+        admission=_Admission(),
+        provider=SelfCaptureProviderAdapter(runtime, _ChannelReset()),
+        provider_request_factory=request_factory,
+        source_factory=source_factory,
+        vad_factory=lambda _config: object(),
+        run_audio_loop=run_audio_loop,
+        vad_sink=harness.self_owner,
+    )
+
+    async def replace_self_stt(smooth: bool) -> None:
+        await self_application.replace_provider(smooth_local=smooth)
+
+    self_application = SelfCaptureApplicationOwner(
+        settings_provider=lambda: SelfCaptureApplicationSettings(
+            config=build_self_capture_session_config_from_vnext(settings_owner.canonical),
+            provider_id=settings_owner.canonical.intent.stt.provider,
+            qwen_region=None,
+        ),
+        runtime_available=lambda: True,
+        capture_owner=lambda: capture_owner,
+        capture_owner_if_created=lambda: capture_owner,
+        persist_manual_fallback=lambda: True,
+        reset_local_pending=lambda: None,
+        clear_gpu_pending=lambda: None,
+        overlay_state_provider=lambda: "off",
+        mark_promo_eligible=lambda: None,
+        dashboard_enabled_sink=lambda _value: None,
+        dashboard_needs_key_sink=lambda _value: None,
+        dashboard_needs_key=lambda _value: False,
+        state_sink=lambda _snapshot: None,
+        sync_effective_flags=lambda: None,
+        sync_local_notice=lambda: None,
+        log_basic=lambda _message: None,
+        log_detailed=lambda _message, _level: None,
+    )
+    await capture_owner.apply_intent(config_a, enabled=True, explicit_toggle_off=False)
+    source = capture_owner.source
+    loop_task = capture_owner.loop_task
+    assert source is sources[0]
+    assert loop_task is not None
+    initial_provider = runtime.current_provider("self")
+    assert initial_provider is not None
+    assert initial_provider.stt_provider_name is STTProviderName.ROLLING_FREE
+    assert initial_provider._active_session.provider_name is STTProviderName.GEMINI_TRANSCRIBE
+
+    components = compose_provider_runtime(
+        config_path=tmp_path / "settings.json",
+        settings=settings_owner,
+        llm_runtime_provider=lambda: llm_runtime,
+        local_asr_runtime_provider=lambda: runtime,
+        translation_runtime_configuration_provider=lambda: None,
+        self_capture_provider=lambda: capture_owner,
+        self_capture_owner=lambda: capture_owner,
+        peer=lambda: peer,
+        peer_desired=lambda _settings: False,
+        canonical_settings=lambda value: value,
+        clear_local_pending=lambda: None,
+        sync_local_notice=lambda: None,
+        managed_pending_sink=lambda _value: None,
+        managed_pending_provider=lambda: False,
+        dashboard_managed_pending_sink=lambda _value: None,
+        sync_effective_flags=lambda _settings: None,
+        refresh_overlay=lambda: None,
+        refresh_peer_runtime=_noop,
+        replace_self_stt=replace_self_stt,
+        self_state_sink=lambda _snapshot: None,
+        self_availability=lambda snapshot: snapshot.provider_status.value == "ready",
+        gpu_recovery=lambda _settings, _plan: _noop(),
+        managed_release=lambda: _ManagedRelease(),
+        managed_delegate_ready=lambda: None,
+        runtime_logging=SimpleNamespace(),
+        translation_needs_key_sink=lambda _value: None,
+        usage_refresh=_noop,
+        failure_sink=lambda _message: None,
+        success_sink=lambda _message: None,
+        additional_signature_sink=lambda _settings: None,
+    )
+    components.sync_signatures(settings_owner.canonical)
+
+    results = SettingsTransactionResultOwner()
+    provider_application = ProviderApplicationOwner(
+        settings=settings_owner,
+        runtime=components.runtime,
+        merge_settings=copy.deepcopy,
+        preserve_before_replace=lambda value: _preserve(value),
+        sync_ui=lambda: None,
+        order24_patch_provider=lambda _value: None,
+        apply_order24=lambda _value: _false(),
+        remember_order22=lambda _value: None,
+        mutation_service_provider=lambda: None,
+        save_failure_sink=lambda _message: None,
+        results=results,
+        sync_memory=lambda _value: None,
+        capture_runtime_signatures=components.capture_signatures_before_canonical_mutation,
+        sync_signatures=components.sync_signatures,
+        consume_superseded_settings=lambda _value: False,
+        active_local_asr_change=lambda _base, _next: False,
+        compensate_local_asr=lambda **_kwargs: _noop(),
+        llm_retry_pending=lambda: False,
+        mark_llm_retry=lambda: None,
+    )
+    ui_settings = UiSettingsRuntimeAdapter(
+        settings=settings_owner,
+        projection=SimpleNamespace(),
+        application=SimpleNamespace(),
+        merge_provider_settings=lambda value: value,
+        telemetry_enabled_settings=lambda value, _enabled: value,
+    )
+    ui_provider = UiProviderRuntimeAdapter(
+        settings=settings_owner,
+        provider_application=provider_application,
+        gpu=SimpleNamespace(),
+        managed=SimpleNamespace(),
+        credential_verification=SimpleNamespace(),
+        provider_settings=SimpleNamespace(),
+        build_byok_target_settings=lambda _settings: None,
+    )
+    boundary = UiApplicationBoundary(
+        startup=SimpleNamespace(),
+        input_runtime=SimpleNamespace(),
+        peer_capture=SimpleNamespace(),
+        settings=ui_settings,
+        provider=ui_provider,
+        microphone=SimpleNamespace(),
+        overlay=SimpleNamespace(),
+        managed=SimpleNamespace(),
+        engagement=SimpleNamespace(),
+        diagnostics=SimpleNamespace(),
+        state=SimpleNamespace(snapshot=SimpleNamespace()),
+        runtime_shutdown=_NoopPort(),
+        runtime_logging=SimpleNamespace(),
+        settings_secrets=SimpleNamespace(),
+        osc_state_publisher=lambda: None,
+    )
+
+    soniox_intent = ProviderApplyIntent((SelfSttProviderEdit(STTProviderName.SONIOX),))
+    await boundary.apply_provider_intent(soniox_intent)
+    assert settings_owner.canonical is not None
+    assert settings_owner.canonical.intent.stt.provider == STTProviderName.SONIOX.value
+    soniox_provider = runtime.current_provider("self")
+    assert soniox_provider is not None
+    assert soniox_provider.stt_provider_name is STTProviderName.SONIOX
+    assert runtime.snapshot.channel_for("self").provider_id == STTProviderName.SONIOX.value
+    expected_soniox = build_self_capture_session_config_from_vnext(settings_owner.canonical)
+    assert capture_owner.snapshot.runtime_signature == expected_soniox.runtime_signature
+    assert capture_owner.snapshot.desired_active is True
+    assert capture_owner.snapshot.effective_active is True
+    assert capture_owner.source is source
+    assert capture_owner.loop_task is loop_task
+
+    rolling_intent = ProviderApplyIntent((SelfSttProviderEdit(STTProviderName.ROLLING_FREE),))
+    soniox_provider._active_utterance_id = uuid4()
+    apply_rolling = asyncio.create_task(boundary.apply_provider_intent(rolling_intent))
+    for _ in range(1000):
+        await asyncio.sleep(0.001)
+        if runtime.snapshot.channel_for("self").pending_handoff or apply_rolling.done():
+            break
+    assert not apply_rolling.done()
+    assert runtime.snapshot.channel_for("self").pending_handoff is True
+    assert runtime.snapshot.channel_for("self").provider_id == STTProviderName.SONIOX.value
+    assert capture_owner.snapshot.provider_id == STTProviderName.SONIOX.value
+    await harness.self_owner.handle_vad_event(SpeechEnd(uuid4()))
+    await apply_rolling
+
+    restored = runtime.current_provider("self")
+    assert restored is not None
+    assert restored.stt_provider_name is STTProviderName.ROLLING_FREE
+    assert isinstance(restored.backend, RollingSTTBackend)
+    assert restored.backend.providers[0].name is STTProviderName.GEMINI_TRANSCRIBE
+    assert runtime.snapshot.channel_for("self").provider_id == STTProviderName.ROLLING_FREE.value
+    assert settings_owner.canonical is not None
+    assert settings_owner.canonical.intent.stt.provider == STTProviderName.ROLLING_FREE.value
+    expected = build_self_capture_session_config_from_vnext(settings_owner.canonical)
+    assert capture_owner.snapshot.runtime_signature == expected.runtime_signature
+    assert capture_owner.snapshot.desired_active is True
+    assert capture_owner.snapshot.effective_active is True
+    assert capture_owner.source is source
+    assert capture_owner.loop_task is loop_task
+
+    await capture_owner.close()
+    await runtime.close()
+
+
+async def _preserve(value):
+    return value
+
+
+async def _false() -> bool:
+    return False

--- a/tests/app/test_ui_provider_runtime_adapter.py
+++ b/tests/app/test_ui_provider_runtime_adapter.py
@@ -79,8 +79,8 @@ async def test_rolling_member_secret_change_rebinds_without_provider_apply() -> 
     apply = AsyncMock(return_value=True)
     rebound: list[tuple[str, str]] = []
     adapter = _adapter(settings, change_secret=change_secret, apply=apply)
-    adapter.provider_application.rebind_rolling_stt_secret = (
-        lambda key, value: rebound.append((key, value))
+    adapter.provider_application.rebind_rolling_stt_secret = lambda key, value: rebound.append(
+        (key, value)
     )
 
     assert await adapter.persist_provider_secret_change(
@@ -99,14 +99,17 @@ async def test_failed_secret_change_does_not_rebind_rolling() -> None:
     apply = AsyncMock(return_value=True)
     rebound: list[tuple[str, str]] = []
     adapter = _adapter(settings, change_secret=change_secret, apply=apply)
-    adapter.provider_application.rebind_rolling_stt_secret = (
-        lambda key, value: rebound.append((key, value))
+    adapter.provider_application.rebind_rolling_stt_secret = lambda key, value: rebound.append(
+        (key, value)
     )
 
-    assert await adapter.persist_provider_secret_change(
-        "gemini_transcribe_api_key",
-        "rotated-key",
-    ) is False
+    assert (
+        await adapter.persist_provider_secret_change(
+            "gemini_transcribe_api_key",
+            "rotated-key",
+        )
+        is False
+    )
 
     assert rebound == []
     apply.assert_not_awaited()

--- a/tests/architecture/test_lifecycle_task_guard.py
+++ b/tests/architecture/test_lifecycle_task_guard.py
@@ -30,7 +30,7 @@ LEGACY_TASK_CREATION_ALLOWLIST = Counter(
         ("src/puripuly_heart/core/overlay/presenter.py", ASYNCIO_CREATE_TASK): 1,
         ("src/puripuly_heart/providers/stt/custom.py", ASYNCIO_CREATE_TASK): 1,
         ("src/puripuly_heart/providers/stt/elevenlabs_scribe.py", ASYNCIO_CREATE_TASK): 2,
-        ("src/puripuly_heart/providers/stt/gemini_transcribe.py", ASYNCIO_CREATE_TASK): 1,
+        ("src/puripuly_heart/providers/stt/gemini_transcribe.py", ASYNCIO_CREATE_TASK): 3,
         ("src/puripuly_heart/providers/stt/soniox.py", ASYNCIO_CREATE_TASK): 3,
         ("src/puripuly_heart/ui/components/subtab_shell.py", BARE_RUN_TASK): 1,
         ("src/puripuly_heart/ui/flet_runtime.py", BARE_RUN_TASK): 1,
@@ -134,7 +134,7 @@ TASK_CREATION_ALLOWLIST_RATIONALES = {
     (
         "src/puripuly_heart/providers/stt/gemini_transcribe.py",
         ASYNCIO_CREATE_TASK,
-    ): "Gemini Transcribe Live session owns its receive task under provider session close semantics",
+    ): "Gemini Transcribe Live session owns its send, receive, and per-turn finalize-timeout tasks and cancels them through session close and turn acknowledgement",
     (
         "src/puripuly_heart/providers/stt/elevenlabs_scribe.py",
         ASYNCIO_CREATE_TASK,

--- a/tests/architecture/test_translation_coordinator_retirement.py
+++ b/tests/architecture/test_translation_coordinator_retirement.py
@@ -7,6 +7,7 @@ from tests.helpers.paths import REPO_ROOT, SOURCE_ROOT
 
 TEST_ROOT = REPO_ROOT / "tests"
 TRANSLATION_CONSUMERS = {
+    "app/test_stt_provider_apply_vertical.py",
     "core/test_audio_vad_loop.py",
     "core/test_channel_runtime.py",
     "core/test_context_memory.py",

--- a/tests/ui/test_app_branches.py
+++ b/tests/ui/test_app_branches.py
@@ -24,6 +24,8 @@ from puripuly_heart.app.ports.settings_view import (
     OpenRouterPkceTarget,
     OverlaySettingsSnapshot,
     PromptApplyIntent,
+    ProviderApplyIntent,
+    SelfSttProviderEdit,
 )
 from puripuly_heart.app.ports.ui_models import OverlayPeerPresentationState
 from puripuly_heart.app.services.application_shutdown import (
@@ -41,6 +43,7 @@ from puripuly_heart.config.provider_values import (
     OpenRouterCredentialSource,
     OpenRouterLLMModel,
     OpenRouterSelectionAlias,
+    STTProviderName,
 )
 from puripuly_heart.config.settings_vnext.schema import AppSettingsVNext
 from puripuly_heart.config.translation_values import TranslationConnection, TranslationModel
@@ -3162,23 +3165,39 @@ async def test_on_nav_change_applies_provider_changes_when_leaving_settings(
     app.view_dashboard = object()
     app.view_logs = SimpleNamespace(scroll_to_bottom=lambda: asyncio.sleep(0))
     app.view_about = object()
+
+    canonical = AppSettingsVNext()
+    canonical = replace(
+        canonical,
+        intent=replace(
+            canonical.intent,
+            stt=replace(
+                canonical.intent.stt,
+                provider=STTProviderName.SONIOX.value,
+            ),
+        ),
+    )
+    pending_intent = ProviderApplyIntent((SelfSttProviderEdit(STTProviderName.ROLLING_FREE),))
     app.view_settings = SimpleNamespace(
         has_provider_changes=True,
-        consume_provider_apply_settings=lambda: "merged-settings",
+        consume_provider_apply_settings=lambda: pending_intent,
         refresh_prompt_if_empty=lambda: None,
     )
     app.content_area = DummyContent()
-    seen: list[object] = []
+    applied_provider_targets: list[str] = []
     auto_installs: list[str] = []
 
-    async def fake_apply_providers(settings) -> bool:
-        seen.append(settings)
+    async def fake_apply_providers(settings: AppSettingsVNext | None = None) -> bool:
+        assert settings is not None
+        applied_provider_targets.append(settings.intent.stt.provider)
+        controller.settings = settings
         return True
 
     async def fake_auto_install() -> None:
         auto_installs.append("started")
 
     controller = SimpleNamespace(
+        settings=canonical,
         apply_providers=fake_apply_providers,
         install_selected_gpu_model_if_needed=fake_auto_install,
     )
@@ -3189,7 +3208,9 @@ async def test_on_nav_change_applies_provider_changes_when_leaving_settings(
     assert app.view_settings.has_provider_changes is False
     assert len(app.page.tasks) >= 1
     await app.page.tasks[0]()
-    assert seen == ["merged-settings"]
+    assert applied_provider_targets == [STTProviderName.ROLLING_FREE.value]
+    assert canonical.intent.stt.provider == STTProviderName.SONIOX.value
+    assert controller.settings.intent.stt.provider == STTProviderName.ROLLING_FREE.value
     assert auto_installs == []
 
 

--- a/tests/ui/test_app_branches.py
+++ b/tests/ui/test_app_branches.py
@@ -3147,8 +3147,15 @@ async def test_on_nav_change_merges_current_languages_into_prompt_only_apply() -
     assert events == [("apply", pending_settings)]
 
 
+@pytest.mark.parametrize(
+    ("exit_tab", "expected_view"),
+    ((0, "view_dashboard"), (2, "view_logs"), (3, "view_about")),
+)
 @pytest.mark.asyncio
-async def test_on_nav_change_applies_provider_changes_when_leaving_settings() -> None:
+async def test_on_nav_change_applies_provider_changes_when_leaving_settings(
+    exit_tab: int,
+    expected_view: str,
+) -> None:
     app = TranslatorApp.__new__(TranslatorApp)
     app.page = DummyPage()
     app._current_tab = 1
@@ -3177,13 +3184,12 @@ async def test_on_nav_change_applies_provider_changes_when_leaving_settings() ->
     )
     app._ui_application = compose_test_ui_application_boundary(controller)
 
-    app._on_nav_change(0)
-    assert app.content_area.content is app.view_dashboard
+    app._on_nav_change(exit_tab)
+    assert app.content_area.content is getattr(app, expected_view)
     assert app.view_settings.has_provider_changes is False
-    assert len(app.page.tasks) == 1
+    assert len(app.page.tasks) >= 1
     await app.page.tasks[0]()
     assert seen == ["merged-settings"]
-    assert len(app.page.tasks) == 1
     assert auto_installs == []
 
 

--- a/tests/ui/test_settings_view_branches.py
+++ b/tests/ui/test_settings_view_branches.py
@@ -2479,6 +2479,24 @@ def test_on_stt_selected_updates_provider_and_pipeline_flags(
     assert changed == []
 
 
+def test_on_stt_selected_stages_provider_without_immediate_apply(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = _vnext(stt_provider=STTProviderName.SONIOX.value)
+    applied: list[object] = []
+    view, _ = _make_settings_view(monkeypatch)
+    view.load_from_settings(settings, config_path=Path("settings.json"))
+    view.on_providers_changed = lambda: applied.append(True)
+
+    view._on_stt_selected(STTProviderName.ROLLING_FREE.value)
+
+    pending = view.build_provider_apply_settings()
+    assert settings.intent.stt.provider == STTProviderName.SONIOX.value
+    assert pending is not None
+    assert pending.intent.stt.provider == STTProviderName.ROLLING_FREE.value
+    assert applied == []
+
+
 def test_on_stt_selected_routes_compatibility_warning_through_snackbar_callback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/ui/test_settings_view_branches.py
+++ b/tests/ui/test_settings_view_branches.py
@@ -725,6 +725,7 @@ def _make_llm_selection_view(
         "DEFAULT PROMPT",
     )
     view._update_peer_provider_visibility = lambda: None
+    view._sync_cloud_free_tier_card = lambda settings=None: None
     return view
 
 


### PR DESCRIPTION
Staged provider intent (notably Self STT) is now applied to the live runtime when leaving Settings, with convergence guards and disabled-state preservation.

- Fix live Self STT convergence when applying Settings providers (7eb9b623)
- Preserve disabled Self STT and strengthen provider apply regressions (960a822)
- Revert ARCHITECTURE.md churn, then clarify disabled prepare-vs-handoff in one line (2e34c2ed, 16ca3ffa)
- Fix failing architecture guard allowlists and settings view branch mocks (1af8053c)

Verified: full pytest suite passes, ruff and black clean.